### PR TITLE
Parse parameter decorators

### DIFF
--- a/src/parser/lval.js
+++ b/src/parser/lval.js
@@ -162,7 +162,14 @@ pp.parseBindingList = function (close, allowEmpty, allowTrailingComma) {
       this.expect(close);
       break;
     } else {
+      let decorators = [];
+      while (this.match(tt.at)) {
+        decorators.push(this.parseDecorator());
+      }
       let left = this.parseMaybeDefault();
+      if (decorators.length) {
+        left.decorators = decorators;
+      }
       this.parseAssignableListItemTypes(left);
       elts.push(this.parseMaybeDefault(null, null, left));
     }

--- a/test/fixtures/experimental/decorators/class-method-parameter/actual.js
+++ b/test/fixtures/experimental/decorators/class-method-parameter/actual.js
@@ -1,0 +1,3 @@
+class Foo {
+  constructor(@foo() x, @bar({ a: 123 }) @baz() y) {}
+}

--- a/test/fixtures/experimental/decorators/class-method-parameter/expected.json
+++ b/test/fixtures/experimental/decorators/class-method-parameter/expected.json
@@ -1,0 +1,388 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 67,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 67,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 67,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 9,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 9
+            }
+          },
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 10,
+          "end": 67,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 10
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassMethod",
+              "start": 14,
+              "end": 65,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 53
+                }
+              },
+              "computed": false,
+              "key": {
+                "type": "Identifier",
+                "start": 14,
+                "end": 25,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 13
+                  }
+                },
+                "name": "constructor"
+              },
+              "static": false,
+              "kind": "constructor",
+              "id": null,
+              "generator": false,
+              "expression": false,
+              "params": [
+                {
+                  "type": "Identifier",
+                  "start": 33,
+                  "end": 34,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 21
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 22
+                    }
+                  },
+                  "name": "x",
+                  "decorators": [
+                    {
+                      "type": "Decorator",
+                      "start": 26,
+                      "end": 32,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 14
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 20
+                        }
+                      },
+                      "expression": {
+                        "type": "CallExpression",
+                        "start": 27,
+                        "end": 32,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 15
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 20
+                          }
+                        },
+                        "callee": {
+                          "type": "Identifier",
+                          "start": 27,
+                          "end": 30,
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 15
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 18
+                            }
+                          },
+                          "name": "foo"
+                        },
+                        "arguments": []
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "Identifier",
+                  "start": 60,
+                  "end": 61,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 48
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 49
+                    }
+                  },
+                  "name": "y",
+                  "decorators": [
+                    {
+                      "type": "Decorator",
+                      "start": 36,
+                      "end": 52,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 24
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 40
+                        }
+                      },
+                      "expression": {
+                        "type": "CallExpression",
+                        "start": 37,
+                        "end": 52,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 25
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 40
+                          }
+                        },
+                        "callee": {
+                          "type": "Identifier",
+                          "start": 37,
+                          "end": 40,
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 25
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 28
+                            }
+                          },
+                          "name": "bar"
+                        },
+                        "arguments": [
+                          {
+                            "type": "ObjectExpression",
+                            "start": 41,
+                            "end": 51,
+                            "loc": {
+                              "start": {
+                                "line": 2,
+                                "column": 29
+                              },
+                              "end": {
+                                "line": 2,
+                                "column": 39
+                              }
+                            },
+                            "properties": [
+                              {
+                                "type": "ObjectProperty",
+                                "start": 43,
+                                "end": 49,
+                                "loc": {
+                                  "start": {
+                                    "line": 2,
+                                    "column": 31
+                                  },
+                                  "end": {
+                                    "line": 2,
+                                    "column": 37
+                                  }
+                                },
+                                "method": false,
+                                "shorthand": false,
+                                "computed": false,
+                                "key": {
+                                  "type": "Identifier",
+                                  "start": 43,
+                                  "end": 44,
+                                  "loc": {
+                                    "start": {
+                                      "line": 2,
+                                      "column": 31
+                                    },
+                                    "end": {
+                                      "line": 2,
+                                      "column": 32
+                                    }
+                                  },
+                                  "name": "a"
+                                },
+                                "value": {
+                                  "type": "NumericLiteral",
+                                  "start": 46,
+                                  "end": 49,
+                                  "loc": {
+                                    "start": {
+                                      "line": 2,
+                                      "column": 34
+                                    },
+                                    "end": {
+                                      "line": 2,
+                                      "column": 37
+                                    }
+                                  },
+                                  "extra": {
+                                    "rawValue": 123,
+                                    "raw": "123"
+                                  },
+                                  "value": 123
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "type": "Decorator",
+                      "start": 53,
+                      "end": 59,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 41
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 47
+                        }
+                      },
+                      "expression": {
+                        "type": "CallExpression",
+                        "start": 54,
+                        "end": 59,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 42
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 47
+                          }
+                        },
+                        "callee": {
+                          "type": "Identifier",
+                          "start": 54,
+                          "end": 57,
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 42
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 45
+                            }
+                          },
+                          "name": "baz"
+                        },
+                        "arguments": []
+                      }
+                    }
+                  ]
+                }
+              ],
+              "body": {
+                "type": "BlockStatement",
+                "start": 63,
+                "end": 65,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 51
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 53
+                  }
+                },
+                "body": [],
+                "directives": []
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/experimental/decorators/export-default-declaration-function-declaration-parameter/actual.js
+++ b/test/fixtures/experimental/decorators/export-default-declaration-function-declaration-parameter/actual.js
@@ -1,0 +1,1 @@
+export default function func(@foo() x, @bar({ a: 123 }) @baz() y) {}

--- a/test/fixtures/experimental/decorators/export-default-declaration-function-declaration-parameter/expected.json
+++ b/test/fixtures/experimental/decorators/export-default-declaration-function-declaration-parameter/expected.json
@@ -1,0 +1,350 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 68,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 68
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 68,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 68
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ExportDefaultDeclaration",
+        "start": 0,
+        "end": 68,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 68
+          }
+        },
+        "declaration": {
+          "type": "FunctionDeclaration",
+          "start": 15,
+          "end": 68,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 15
+            },
+            "end": {
+              "line": 1,
+              "column": 68
+            }
+          },
+          "id": {
+            "type": "Identifier",
+            "start": 24,
+            "end": 28,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 24
+              },
+              "end": {
+                "line": 1,
+                "column": 28
+              }
+            },
+            "name": "func"
+          },
+          "generator": false,
+          "expression": false,
+          "params": [
+            {
+              "type": "Identifier",
+              "start": 36,
+              "end": 37,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 36
+                },
+                "end": {
+                  "line": 1,
+                  "column": 37
+                }
+              },
+              "name": "x",
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start": 29,
+                  "end": 35,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 29
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 35
+                    }
+                  },
+                  "expression": {
+                    "type": "CallExpression",
+                    "start": 30,
+                    "end": 35,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 30
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 35
+                      }
+                    },
+                    "callee": {
+                      "type": "Identifier",
+                      "start": 30,
+                      "end": 33,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 30
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 33
+                        }
+                      },
+                      "name": "foo"
+                    },
+                    "arguments": []
+                  }
+                }
+              ]
+            },
+            {
+              "type": "Identifier",
+              "start": 63,
+              "end": 64,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 63
+                },
+                "end": {
+                  "line": 1,
+                  "column": 64
+                }
+              },
+              "name": "y",
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start": 39,
+                  "end": 55,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 39
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 55
+                    }
+                  },
+                  "expression": {
+                    "type": "CallExpression",
+                    "start": 40,
+                    "end": 55,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 40
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 55
+                      }
+                    },
+                    "callee": {
+                      "type": "Identifier",
+                      "start": 40,
+                      "end": 43,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 40
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 43
+                        }
+                      },
+                      "name": "bar"
+                    },
+                    "arguments": [
+                      {
+                        "type": "ObjectExpression",
+                        "start": 44,
+                        "end": 54,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 44
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 54
+                          }
+                        },
+                        "properties": [
+                          {
+                            "type": "ObjectProperty",
+                            "start": 46,
+                            "end": 52,
+                            "loc": {
+                              "start": {
+                                "line": 1,
+                                "column": 46
+                              },
+                              "end": {
+                                "line": 1,
+                                "column": 52
+                              }
+                            },
+                            "method": false,
+                            "shorthand": false,
+                            "computed": false,
+                            "key": {
+                              "type": "Identifier",
+                              "start": 46,
+                              "end": 47,
+                              "loc": {
+                                "start": {
+                                  "line": 1,
+                                  "column": 46
+                                },
+                                "end": {
+                                  "line": 1,
+                                  "column": 47
+                                }
+                              },
+                              "name": "a"
+                            },
+                            "value": {
+                              "type": "NumericLiteral",
+                              "start": 49,
+                              "end": 52,
+                              "loc": {
+                                "start": {
+                                  "line": 1,
+                                  "column": 49
+                                },
+                                "end": {
+                                  "line": 1,
+                                  "column": 52
+                                }
+                              },
+                              "extra": {
+                                "rawValue": 123,
+                                "raw": "123"
+                              },
+                              "value": 123
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "Decorator",
+                  "start": 56,
+                  "end": 62,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 56
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 62
+                    }
+                  },
+                  "expression": {
+                    "type": "CallExpression",
+                    "start": 57,
+                    "end": 62,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 57
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 62
+                      }
+                    },
+                    "callee": {
+                      "type": "Identifier",
+                      "start": 57,
+                      "end": 60,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 57
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 60
+                        }
+                      },
+                      "name": "baz"
+                    },
+                    "arguments": []
+                  }
+                }
+              ]
+            }
+          ],
+          "body": {
+            "type": "BlockStatement",
+            "start": 66,
+            "end": 68,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 66
+              },
+              "end": {
+                "line": 1,
+                "column": 68
+              }
+            },
+            "body": [],
+            "directives": []
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/experimental/decorators/export-default-declaration-function-declaration-parameter/options.json
+++ b/test/fixtures/experimental/decorators/export-default-declaration-function-declaration-parameter/options.json
@@ -1,0 +1,3 @@
+{
+  "sourceType": "module"
+}

--- a/test/fixtures/experimental/decorators/function-declaration-parameter/actual.js
+++ b/test/fixtures/experimental/decorators/function-declaration-parameter/actual.js
@@ -1,0 +1,1 @@
+function func(@foo() x, @bar({ a: 123 }) @baz() y) {}

--- a/test/fixtures/experimental/decorators/function-declaration-parameter/expected.json
+++ b/test/fixtures/experimental/decorators/function-declaration-parameter/expected.json
@@ -1,0 +1,335 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 53,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 53
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 53,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 53
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start": 0,
+        "end": 53,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 53
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 9,
+          "end": 13,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 9
+            },
+            "end": {
+              "line": 1,
+              "column": 13
+            }
+          },
+          "name": "func"
+        },
+        "generator": false,
+        "expression": false,
+        "params": [
+          {
+            "type": "Identifier",
+            "start": 21,
+            "end": 22,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 21
+              },
+              "end": {
+                "line": 1,
+                "column": 22
+              }
+            },
+            "name": "x",
+            "decorators": [
+              {
+                "type": "Decorator",
+                "start": 14,
+                "end": 20,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 20
+                  }
+                },
+                "expression": {
+                  "type": "CallExpression",
+                  "start": 15,
+                  "end": 20,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 15
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 20
+                    }
+                  },
+                  "callee": {
+                    "type": "Identifier",
+                    "start": 15,
+                    "end": 18,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 15
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 18
+                      }
+                    },
+                    "name": "foo"
+                  },
+                  "arguments": []
+                }
+              }
+            ]
+          },
+          {
+            "type": "Identifier",
+            "start": 48,
+            "end": 49,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 48
+              },
+              "end": {
+                "line": 1,
+                "column": 49
+              }
+            },
+            "name": "y",
+            "decorators": [
+              {
+                "type": "Decorator",
+                "start": 24,
+                "end": 40,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 24
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 40
+                  }
+                },
+                "expression": {
+                  "type": "CallExpression",
+                  "start": 25,
+                  "end": 40,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 25
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 40
+                    }
+                  },
+                  "callee": {
+                    "type": "Identifier",
+                    "start": 25,
+                    "end": 28,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 25
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 28
+                      }
+                    },
+                    "name": "bar"
+                  },
+                  "arguments": [
+                    {
+                      "type": "ObjectExpression",
+                      "start": 29,
+                      "end": 39,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 29
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 39
+                        }
+                      },
+                      "properties": [
+                        {
+                          "type": "ObjectProperty",
+                          "start": 31,
+                          "end": 37,
+                          "loc": {
+                            "start": {
+                              "line": 1,
+                              "column": 31
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 37
+                            }
+                          },
+                          "method": false,
+                          "shorthand": false,
+                          "computed": false,
+                          "key": {
+                            "type": "Identifier",
+                            "start": 31,
+                            "end": 32,
+                            "loc": {
+                              "start": {
+                                "line": 1,
+                                "column": 31
+                              },
+                              "end": {
+                                "line": 1,
+                                "column": 32
+                              }
+                            },
+                            "name": "a"
+                          },
+                          "value": {
+                            "type": "NumericLiteral",
+                            "start": 34,
+                            "end": 37,
+                            "loc": {
+                              "start": {
+                                "line": 1,
+                                "column": 34
+                              },
+                              "end": {
+                                "line": 1,
+                                "column": 37
+                              }
+                            },
+                            "extra": {
+                              "rawValue": 123,
+                              "raw": "123"
+                            },
+                            "value": 123
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "Decorator",
+                "start": 41,
+                "end": 47,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 41
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 47
+                  }
+                },
+                "expression": {
+                  "type": "CallExpression",
+                  "start": 42,
+                  "end": 47,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 42
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 47
+                    }
+                  },
+                  "callee": {
+                    "type": "Identifier",
+                    "start": 42,
+                    "end": 45,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 42
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 45
+                      }
+                    },
+                    "name": "baz"
+                  },
+                  "arguments": []
+                }
+              }
+            ]
+          }
+        ],
+        "body": {
+          "type": "BlockStatement",
+          "start": 51,
+          "end": 53,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 51
+            },
+            "end": {
+              "line": 1,
+              "column": 53
+            }
+          },
+          "body": [],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/experimental/decorators/function-expression-parameter/actual.js
+++ b/test/fixtures/experimental/decorators/function-expression-parameter/actual.js
@@ -1,0 +1,1 @@
+const func = function (@foo() x, @bar({ a: 123 }) @baz() y) {};

--- a/test/fixtures/experimental/decorators/function-expression-parameter/expected.json
+++ b/test/fixtures/experimental/decorators/function-expression-parameter/expected.json
@@ -1,0 +1,369 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 63,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 63
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 63,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 63
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 63,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 63
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 6,
+            "end": 62,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 6
+              },
+              "end": {
+                "line": 1,
+                "column": 62
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 6,
+              "end": 10,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1,
+                  "column": 10
+                }
+              },
+              "name": "func"
+            },
+            "init": {
+              "type": "FunctionExpression",
+              "start": 13,
+              "end": 62,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 13
+                },
+                "end": {
+                  "line": 1,
+                  "column": 62
+                }
+              },
+              "id": null,
+              "generator": false,
+              "expression": false,
+              "params": [
+                {
+                  "type": "Identifier",
+                  "start": 30,
+                  "end": 31,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 30
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 31
+                    }
+                  },
+                  "name": "x",
+                  "decorators": [
+                    {
+                      "type": "Decorator",
+                      "start": 23,
+                      "end": 29,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 23
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 29
+                        }
+                      },
+                      "expression": {
+                        "type": "CallExpression",
+                        "start": 24,
+                        "end": 29,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 24
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 29
+                          }
+                        },
+                        "callee": {
+                          "type": "Identifier",
+                          "start": 24,
+                          "end": 27,
+                          "loc": {
+                            "start": {
+                              "line": 1,
+                              "column": 24
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 27
+                            }
+                          },
+                          "name": "foo"
+                        },
+                        "arguments": []
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "Identifier",
+                  "start": 57,
+                  "end": 58,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 57
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 58
+                    }
+                  },
+                  "name": "y",
+                  "decorators": [
+                    {
+                      "type": "Decorator",
+                      "start": 33,
+                      "end": 49,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 33
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 49
+                        }
+                      },
+                      "expression": {
+                        "type": "CallExpression",
+                        "start": 34,
+                        "end": 49,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 34
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 49
+                          }
+                        },
+                        "callee": {
+                          "type": "Identifier",
+                          "start": 34,
+                          "end": 37,
+                          "loc": {
+                            "start": {
+                              "line": 1,
+                              "column": 34
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 37
+                            }
+                          },
+                          "name": "bar"
+                        },
+                        "arguments": [
+                          {
+                            "type": "ObjectExpression",
+                            "start": 38,
+                            "end": 48,
+                            "loc": {
+                              "start": {
+                                "line": 1,
+                                "column": 38
+                              },
+                              "end": {
+                                "line": 1,
+                                "column": 48
+                              }
+                            },
+                            "properties": [
+                              {
+                                "type": "ObjectProperty",
+                                "start": 40,
+                                "end": 46,
+                                "loc": {
+                                  "start": {
+                                    "line": 1,
+                                    "column": 40
+                                  },
+                                  "end": {
+                                    "line": 1,
+                                    "column": 46
+                                  }
+                                },
+                                "method": false,
+                                "shorthand": false,
+                                "computed": false,
+                                "key": {
+                                  "type": "Identifier",
+                                  "start": 40,
+                                  "end": 41,
+                                  "loc": {
+                                    "start": {
+                                      "line": 1,
+                                      "column": 40
+                                    },
+                                    "end": {
+                                      "line": 1,
+                                      "column": 41
+                                    }
+                                  },
+                                  "name": "a"
+                                },
+                                "value": {
+                                  "type": "NumericLiteral",
+                                  "start": 43,
+                                  "end": 46,
+                                  "loc": {
+                                    "start": {
+                                      "line": 1,
+                                      "column": 43
+                                    },
+                                    "end": {
+                                      "line": 1,
+                                      "column": 46
+                                    }
+                                  },
+                                  "extra": {
+                                    "rawValue": 123,
+                                    "raw": "123"
+                                  },
+                                  "value": 123
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "type": "Decorator",
+                      "start": 50,
+                      "end": 56,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 50
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 56
+                        }
+                      },
+                      "expression": {
+                        "type": "CallExpression",
+                        "start": 51,
+                        "end": 56,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 51
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 56
+                          }
+                        },
+                        "callee": {
+                          "type": "Identifier",
+                          "start": 51,
+                          "end": 54,
+                          "loc": {
+                            "start": {
+                              "line": 1,
+                              "column": 51
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 54
+                            }
+                          },
+                          "name": "baz"
+                        },
+                        "arguments": []
+                      }
+                    }
+                  ]
+                }
+              ],
+              "body": {
+                "type": "BlockStatement",
+                "start": 60,
+                "end": 62,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 60
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 62
+                  }
+                },
+                "body": [],
+                "directives": []
+              }
+            }
+          }
+        ],
+        "kind": "const"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/experimental/decorators/object-method-parameter/actual.js
+++ b/test/fixtures/experimental/decorators/object-method-parameter/actual.js
@@ -1,0 +1,3 @@
+var obj = {
+  method(@foo() x, @bar({ a: 123 }) @baz() y) {}
+};

--- a/test/fixtures/experimental/decorators/object-method-parameter/expected.json
+++ b/test/fixtures/experimental/decorators/object-method-parameter/expected.json
@@ -1,0 +1,406 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 63,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 2
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 63,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 2
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 63,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 2
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 4,
+            "end": 62,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 4
+              },
+              "end": {
+                "line": 3,
+                "column": 1
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 4,
+              "end": 7,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 4
+                },
+                "end": {
+                  "line": 1,
+                  "column": 7
+                }
+              },
+              "name": "obj"
+            },
+            "init": {
+              "type": "ObjectExpression",
+              "start": 10,
+              "end": 62,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 10
+                },
+                "end": {
+                  "line": 3,
+                  "column": 1
+                }
+              },
+              "properties": [
+                {
+                  "type": "ObjectMethod",
+                  "start": 14,
+                  "end": 60,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 48
+                    }
+                  },
+                  "method": true,
+                  "shorthand": false,
+                  "computed": false,
+                  "key": {
+                    "type": "Identifier",
+                    "start": 14,
+                    "end": 20,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 8
+                      }
+                    },
+                    "name": "method"
+                  },
+                  "kind": "method",
+                  "id": null,
+                  "generator": false,
+                  "expression": false,
+                  "params": [
+                    {
+                      "type": "Identifier",
+                      "start": 28,
+                      "end": 29,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 16
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 17
+                        }
+                      },
+                      "name": "x",
+                      "decorators": [
+                        {
+                          "type": "Decorator",
+                          "start": 21,
+                          "end": 27,
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 9
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 15
+                            }
+                          },
+                          "expression": {
+                            "type": "CallExpression",
+                            "start": 22,
+                            "end": 27,
+                            "loc": {
+                              "start": {
+                                "line": 2,
+                                "column": 10
+                              },
+                              "end": {
+                                "line": 2,
+                                "column": 15
+                              }
+                            },
+                            "callee": {
+                              "type": "Identifier",
+                              "start": 22,
+                              "end": 25,
+                              "loc": {
+                                "start": {
+                                  "line": 2,
+                                  "column": 10
+                                },
+                                "end": {
+                                  "line": 2,
+                                  "column": 13
+                                }
+                              },
+                              "name": "foo"
+                            },
+                            "arguments": []
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Identifier",
+                      "start": 55,
+                      "end": 56,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 43
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 44
+                        }
+                      },
+                      "name": "y",
+                      "decorators": [
+                        {
+                          "type": "Decorator",
+                          "start": 31,
+                          "end": 47,
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 19
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 35
+                            }
+                          },
+                          "expression": {
+                            "type": "CallExpression",
+                            "start": 32,
+                            "end": 47,
+                            "loc": {
+                              "start": {
+                                "line": 2,
+                                "column": 20
+                              },
+                              "end": {
+                                "line": 2,
+                                "column": 35
+                              }
+                            },
+                            "callee": {
+                              "type": "Identifier",
+                              "start": 32,
+                              "end": 35,
+                              "loc": {
+                                "start": {
+                                  "line": 2,
+                                  "column": 20
+                                },
+                                "end": {
+                                  "line": 2,
+                                  "column": 23
+                                }
+                              },
+                              "name": "bar"
+                            },
+                            "arguments": [
+                              {
+                                "type": "ObjectExpression",
+                                "start": 36,
+                                "end": 46,
+                                "loc": {
+                                  "start": {
+                                    "line": 2,
+                                    "column": 24
+                                  },
+                                  "end": {
+                                    "line": 2,
+                                    "column": 34
+                                  }
+                                },
+                                "properties": [
+                                  {
+                                    "type": "ObjectProperty",
+                                    "start": 38,
+                                    "end": 44,
+                                    "loc": {
+                                      "start": {
+                                        "line": 2,
+                                        "column": 26
+                                      },
+                                      "end": {
+                                        "line": 2,
+                                        "column": 32
+                                      }
+                                    },
+                                    "method": false,
+                                    "shorthand": false,
+                                    "computed": false,
+                                    "key": {
+                                      "type": "Identifier",
+                                      "start": 38,
+                                      "end": 39,
+                                      "loc": {
+                                        "start": {
+                                          "line": 2,
+                                          "column": 26
+                                        },
+                                        "end": {
+                                          "line": 2,
+                                          "column": 27
+                                        }
+                                      },
+                                      "name": "a"
+                                    },
+                                    "value": {
+                                      "type": "NumericLiteral",
+                                      "start": 41,
+                                      "end": 44,
+                                      "loc": {
+                                        "start": {
+                                          "line": 2,
+                                          "column": 29
+                                        },
+                                        "end": {
+                                          "line": 2,
+                                          "column": 32
+                                        }
+                                      },
+                                      "extra": {
+                                        "rawValue": 123,
+                                        "raw": "123"
+                                      },
+                                      "value": 123
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "Decorator",
+                          "start": 48,
+                          "end": 54,
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 36
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 42
+                            }
+                          },
+                          "expression": {
+                            "type": "CallExpression",
+                            "start": 49,
+                            "end": 54,
+                            "loc": {
+                              "start": {
+                                "line": 2,
+                                "column": 37
+                              },
+                              "end": {
+                                "line": 2,
+                                "column": 42
+                              }
+                            },
+                            "callee": {
+                              "type": "Identifier",
+                              "start": 49,
+                              "end": 52,
+                              "loc": {
+                                "start": {
+                                  "line": 2,
+                                  "column": 37
+                                },
+                                "end": {
+                                  "line": 2,
+                                  "column": 40
+                                }
+                              },
+                              "name": "baz"
+                            },
+                            "arguments": []
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "body": {
+                    "type": "BlockStatement",
+                    "start": 58,
+                    "end": 60,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 46
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 48
+                      }
+                    },
+                    "body": [],
+                    "directives": []
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "kind": "var"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/experimental/decorators/options.json
+++ b/test/fixtures/experimental/decorators/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["decorators"]
+}


### PR DESCRIPTION
Because [Method Parameter Decorators](https://goo.gl/8MmCMG) is now [a TC39 stage 0 proposal](https://github.com/tc39/ecma262/blob/master/stage0.md), I'd like to propose babylon to parse parameter decorators.

While the actual transform is still being debated, it would be great if babylon only parses the syntax and allows users to transform it with third-party plugins. One concrete use case is Angular 2's decorators.

https://phabricator.babeljs.io/T1301

(Reopening #3 that was automatically closed because of rebased `master`)