### PR TITLE
Parse for-await statements when asyncGenerators plugin is active

### DIFF
--- a/test/fixtures/experimental/async-generators/for-await-async-context/actual.js
+++ b/test/fixtures/experimental/async-generators/for-await-async-context/actual.js
@@ -1,0 +1,3 @@
+function f() {
+  for await (let x of y);
+}

--- a/test/fixtures/experimental/async-generators/for-await-async-context/options.json
+++ b/test/fixtures/experimental/async-generators/for-await-async-context/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token (2:6)"
+}

--- a/test/fixtures/experimental/async-generators/for-await-no-in/actual.js
+++ b/test/fixtures/experimental/async-generators/for-await-no-in/actual.js
@@ -1,0 +1,3 @@
+async function f() {
+  for await (let x in y);
+}

--- a/test/fixtures/experimental/async-generators/for-await-no-in/expected.json
+++ b/test/fixtures/experimental/async-generators/for-await-no-in/expected.json
@@ -1,0 +1,184 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 48,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 48,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start": 0,
+        "end": 48,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 15,
+          "end": 16,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 15
+            },
+            "end": {
+              "line": 1,
+              "column": 16
+            }
+          },
+          "name": "f"
+        },
+        "generator": false,
+        "expression": false,
+        "async": true,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start": 19,
+          "end": 48,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 19
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ForAwaitStatement",
+              "start": 23,
+              "end": 46,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 25
+                }
+              },
+              "await": true,
+              "left": {
+                "type": "VariableDeclaration",
+                "start": 34,
+                "end": 39,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 13
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 18
+                  }
+                },
+                "declarations": [
+                  {
+                    "type": "VariableDeclarator",
+                    "start": 38,
+                    "end": 39,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 17
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 18
+                      }
+                    },
+                    "id": {
+                      "type": "Identifier",
+                      "start": 38,
+                      "end": 39,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 17
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 18
+                        }
+                      },
+                      "name": "x"
+                    },
+                    "init": null
+                  }
+                ],
+                "kind": "let"
+              },
+              "right": {
+                "type": "Identifier",
+                "start": 43,
+                "end": 44,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 22
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 23
+                  }
+                },
+                "name": "y"
+              },
+              "body": {
+                "type": "EmptyStatement",
+                "start": 45,
+                "end": 46,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 24
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 25
+                  }
+                }
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/experimental/async-generators/for-await-no-in/options.json
+++ b/test/fixtures/experimental/async-generators/for-await-no-in/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token (2:19)"
+}

--- a/test/fixtures/experimental/async-generators/for-await-no-semi-1/actual.js
+++ b/test/fixtures/experimental/async-generators/for-await-no-semi-1/actual.js
@@ -1,0 +1,3 @@
+async function f() {
+  for await (;false;);
+}

--- a/test/fixtures/experimental/async-generators/for-await-no-semi-1/options.json
+++ b/test/fixtures/experimental/async-generators/for-await-no-semi-1/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token (2:13)"
+}

--- a/test/fixtures/experimental/async-generators/for-await-no-semi-2/actual.js
+++ b/test/fixtures/experimental/async-generators/for-await-no-semi-2/actual.js
@@ -1,0 +1,3 @@
+async function f() {
+  for await (let i = 0;false;);
+}

--- a/test/fixtures/experimental/async-generators/for-await-no-semi-2/options.json
+++ b/test/fixtures/experimental/async-generators/for-await-no-semi-2/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token (2:22)"
+}

--- a/test/fixtures/experimental/async-generators/for-await-no-semi-3/actual.js
+++ b/test/fixtures/experimental/async-generators/for-await-no-semi-3/actual.js
@@ -1,0 +1,3 @@
+async function f() {
+  for await (x = 0;false;);
+}

--- a/test/fixtures/experimental/async-generators/for-await-no-semi-3/options.json
+++ b/test/fixtures/experimental/async-generators/for-await-no-semi-3/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token (2:18)"
+}

--- a/test/fixtures/experimental/async-generators/for-await/actual.js
+++ b/test/fixtures/experimental/async-generators/for-await/actual.js
@@ -1,0 +1,3 @@
+async function f() {
+  for await (let x of y);
+}

--- a/test/fixtures/experimental/async-generators/for-await/expected.json
+++ b/test/fixtures/experimental/async-generators/for-await/expected.json
@@ -1,0 +1,183 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 48,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 48,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "FunctionDeclaration",
+        "start": 0,
+        "end": 48,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 15,
+          "end": 16,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 15
+            },
+            "end": {
+              "line": 1,
+              "column": 16
+            }
+          },
+          "name": "f"
+        },
+        "generator": false,
+        "expression": false,
+        "async": true,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "start": 19,
+          "end": 48,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 19
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ForAwaitStatement",
+              "start": 23,
+              "end": 46,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 25
+                }
+              },
+              "left": {
+                "type": "VariableDeclaration",
+                "start": 34,
+                "end": 39,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 13
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 18
+                  }
+                },
+                "declarations": [
+                  {
+                    "type": "VariableDeclarator",
+                    "start": 38,
+                    "end": 39,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 17
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 18
+                      }
+                    },
+                    "id": {
+                      "type": "Identifier",
+                      "start": 38,
+                      "end": 39,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 17
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 18
+                        }
+                      },
+                      "name": "x"
+                    },
+                    "init": null
+                  }
+                ],
+                "kind": "let"
+              },
+              "right": {
+                "type": "Identifier",
+                "start": 43,
+                "end": 44,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 22
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 23
+                  }
+                },
+                "name": "y"
+              },
+              "body": {
+                "type": "EmptyStatement",
+                "start": 45,
+                "end": 46,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 24
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 25
+                  }
+                }
+              }
+            }
+          ],
+          "directives": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
Per March 2016 TC39 meeting, [async generators and for-await](https://github.com/tc39/proposal-async-iteration) are now at stage 2.  Babylon already supports parsing of async generator functions.  This commit adds support for for-await statements.

For-await statements look like this:

```js
async function f() {
  for await (let x of y);
}
```

I've chosen to output a new node type: "ForAwaitStatement".  Another approach would be to output a "ForOfStatement" with an "await" property set to `true`.

Thanks!