### PR TITLE
Add `tokenize` to the public API.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,4 +20,27 @@ export function parse(input, options) {
   return new Parser(options, input).parse();
 }
 
+export function tokenize(input, options) {
+  let parser = new Parser(options, input);
+  return () => {
+    if (!parser) return null;
+
+    parser.next();
+    if (parser.eat(tokTypes.eof)) {
+      parser = null; // deallocate when done
+      return null;
+    }
+
+    const {state} = parser;
+    return {
+      type: state.type,
+      value: state.value,
+      start: state.start,
+      end: state.end,
+      startLoc: state.startLoc,
+      endLoc: state.endLoc,
+    };
+  };
+}
+
 export { tokTypes };


### PR DESCRIPTION
`tokenize` returns a function that will return the next token for each call, and `null` after tokenizing the source completely.