### PR TITLE
Test babel with dev babylon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+build
 lib
 node_modules

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+MAKEFLAGS = -j1
+
+export NODE_ENV = test
+
+.PHONY: make clean test test-only test-cov test-clean test-travis publish build bootstrap publish-core publish-runtime build-website build-core watch-core build-core-test clean-core prepublish
+
+clean: ; rm -rf ./build
+
+bootstrap-babel: clean
+	mkdir ./build
+	git clone git@github.com:babel/babel.git ./build/babel
+	cd ./build/babel; \
+	make bootstrap
+	find ./build/babel/packages -type d -name 'babylon' -prune -exec rm -rf '{}' \; -exec ln -s '../../../../../' '{}' \;
+
+test-babel:
+	npm run build
+	cd ./build/babel; \
+	make test-only
+


### PR DESCRIPTION
I created a Makefile that can checkout babel and hook the local version of babylon into babel. Then it is possible to run the babel tests with the current local version of babylon.

just run `make bootstrap-babel` once and then `make test-babel`

This is not necessary the ultimate solution, but at least a start to detect regressions.