### PR TITLE
Fix leading comments added from previous node

### DIFF
--- a/src/parser/comments.js
+++ b/src/parser/comments.js
@@ -42,7 +42,7 @@ pp.processComment = function (node) {
 
   let stack = this.state.commentStack;
 
-  let lastChild, trailingComments, i;
+  let lastChild, trailingComments, i, j;
 
   if (this.state.trailingComments.length > 0) {
     // If the first comment in trailingComments comes after the
@@ -93,8 +93,18 @@ pp.processComment = function (node) {
     }
   } else if (this.state.leadingComments.length > 0) {
     if (last(this.state.leadingComments).end <= node.start) {
-      node.leadingComments = this.state.leadingComments;
-      this.state.leadingComments = [];
+      if (this.state.commentPreviousNode) {
+        for (j = 0; j < this.state.leadingComments.length; j++) {
+          if (this.state.leadingComments[j].end < this.state.commentPreviousNode.end) {
+            this.state.leadingComments.splice(j, 1);
+            j--;
+          }
+        }
+      }
+      if (this.state.leadingComments.length > 0) {
+        node.leadingComments = this.state.leadingComments;
+        this.state.leadingComments = [];
+      }
     } else {
       // https://github.com/eslint/espree/issues/2
       //
@@ -130,6 +140,8 @@ pp.processComment = function (node) {
       }
     }
   }
+
+  this.state.commentPreviousNode = node;
 
   if (trailingComments) {
     if (trailingComments.length && trailingComments[0].start >= node.start && last(trailingComments).end <= node.end) {

--- a/test/fixtures/comments/basic/switch-no-default-comment-in-nested-functions/actual.js
+++ b/test/fixtures/comments/basic/switch-no-default-comment-in-nested-functions/actual.js
@@ -6,6 +6,7 @@ module.exports = function(context) {
                 return isConstant(node.expressions[node.expressions.length - 1]);
             // no default
         }
+        
         return false;
     }
 

--- a/test/fixtures/comments/basic/switch-no-default-comment-in-nested-functions/expected.json
+++ b/test/fixtures/comments/basic/switch-no-default-comment-in-nested-functions/expected.json
@@ -1,28 +1,28 @@
 {
   "type": "File",
   "start": 0,
-  "end": 287,
+  "end": 296,
   "loc": {
     "start": {
       "line": 1,
       "column": 0
     },
     "end": {
-      "line": 12,
+      "line": 13,
       "column": 2
     }
   },
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 287,
+    "end": 296,
     "loc": {
       "start": {
         "line": 1,
         "column": 0
       },
       "end": {
-        "line": 12,
+        "line": 13,
         "column": 2
       }
     },
@@ -31,28 +31,28 @@
       {
         "type": "ExpressionStatement",
         "start": 0,
-        "end": 287,
+        "end": 296,
         "loc": {
           "start": {
             "line": 1,
             "column": 0
           },
           "end": {
-            "line": 12,
+            "line": 13,
             "column": 2
           }
         },
         "expression": {
           "type": "AssignmentExpression",
           "start": 0,
-          "end": 286,
+          "end": 295,
           "loc": {
             "start": {
               "line": 1,
               "column": 0
             },
             "end": {
-              "line": 12,
+              "line": 13,
               "column": 1
             }
           },
@@ -108,14 +108,14 @@
           "right": {
             "type": "FunctionExpression",
             "start": 17,
-            "end": 286,
+            "end": 295,
             "loc": {
               "start": {
                 "line": 1,
                 "column": 17
               },
               "end": {
-                "line": 12,
+                "line": 13,
                 "column": 1
               }
             },
@@ -143,14 +143,14 @@
             "body": {
               "type": "BlockStatement",
               "start": 35,
-              "end": 286,
+              "end": 295,
               "loc": {
                 "start": {
                   "line": 1,
                   "column": 35
                 },
                 "end": {
-                  "line": 12,
+                  "line": 13,
                   "column": 1
                 }
               },
@@ -158,14 +158,14 @@
                 {
                   "type": "FunctionDeclaration",
                   "start": 42,
-                  "end": 283,
+                  "end": 292,
                   "loc": {
                     "start": {
                       "line": 3,
                       "column": 4
                     },
                     "end": {
-                      "line": 10,
+                      "line": 11,
                       "column": 5
                     }
                   },
@@ -208,14 +208,14 @@
                   "body": {
                     "type": "BlockStatement",
                     "start": 68,
-                    "end": 283,
+                    "end": 292,
                     "loc": {
                       "start": {
                         "line": 3,
                         "column": 30
                       },
                       "end": {
-                        "line": 10,
+                        "line": 11,
                         "column": 5
                       }
                     },
@@ -571,53 +571,34 @@
                       },
                       {
                         "type": "ReturnStatement",
-                        "start": 264,
-                        "end": 277,
+                        "start": 273,
+                        "end": 286,
                         "loc": {
                           "start": {
-                            "line": 9,
+                            "line": 10,
                             "column": 8
                           },
                           "end": {
-                            "line": 9,
+                            "line": 10,
                             "column": 21
                           }
                         },
                         "argument": {
                           "type": "BooleanLiteral",
-                          "start": 271,
-                          "end": 276,
+                          "start": 280,
+                          "end": 285,
                           "loc": {
                             "start": {
-                              "line": 9,
+                              "line": 10,
                               "column": 15
                             },
                             "end": {
-                              "line": 9,
+                              "line": 10,
                               "column": 20
                             }
                           },
-                          "value": false,
-                          "leadingComments": null
-                        },
-                        "leadingComments": [
-                          {
-                            "type": "CommentLine",
-                            "value": " no default",
-                            "start": 232,
-                            "end": 245,
-                            "loc": {
-                              "start": {
-                                "line": 7,
-                                "column": 12
-                              },
-                              "end": {
-                                "line": 7,
-                                "column": 25
-                              }
-                            }
-                          }
-                        ]
+                          "value": false
+                        }
                       }
                     ],
                     "directives": []

--- a/test/fixtures/jsx/basic/10/expected.json
+++ b/test/fixtures/jsx/basic/10/expected.json
@@ -117,27 +117,8 @@
                   "column": 31
                 }
               },
-              "name": "a",
-              "leadingComments": null
-            },
-            "leadingComments": [
-              {
-                "type": "CommentBlock",
-                "value": " this is a comment ",
-                "start": 4,
-                "end": 27,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 4
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 27
-                  }
-                }
-              }
-            ]
+              "name": "a"
+            }
           },
           "children": [
             {


### PR DESCRIPTION
This fixes an issue that comments were added as leading comments
to expressions, which are not immediately following the comment.

```js
if (a) {
  // comment
}

return a;
```
This example adds `//comment` as leading comment to `return a;`

This was also reported and fixed in espree, and is basically a port to
babylon. eslint/espree#256

this also fixes an issue in babel-eslint with certain rules babel/babel-eslint#289

The only thing is that comments within jsx `<T>{/* comment */}</T> are now not added as leading comment anymore to the closingElement. I'm not really sure if thats wrong, as it is still added as innerComment.