### PR TITLE
Support defaults in Flow's type parameter declarations

### DIFF
--- a/test/fixtures/flow/bounded-polymorphism/1/expected.json
+++ b/test/fixtures/flow/bounded-polymorphism/1/expected.json
@@ -74,7 +74,7 @@
           },
           "params": [
             {
-              "type": "Identifier",
+              "type": "TypeParameter",
               "start": 8,
               "end": 14,
               "loc": {
@@ -88,7 +88,7 @@
                 }
               },
               "name": "T",
-              "typeAnnotation": {
+              "bound": {
                 "type": "TypeAnnotation",
                 "start": 9,
                 "end": 14,
@@ -156,7 +156,7 @@
           "body": []
         }
       }
-    ]
-  },
-  "comments": []
+    ],
+    "directives": []
+  }
 }

--- a/test/fixtures/flow/bounded-polymorphism/2/expected.json
+++ b/test/fixtures/flow/bounded-polymorphism/2/expected.json
@@ -60,6 +60,7 @@
         },
         "generator": false,
         "expression": false,
+        "async": false,
         "typeParameters": {
           "type": "TypeParameterDeclaration",
           "start": 12,
@@ -76,7 +77,7 @@
           },
           "params": [
             {
-              "type": "Identifier",
+              "type": "TypeParameter",
               "start": 13,
               "end": 23,
               "loc": {
@@ -90,7 +91,7 @@
                 }
               },
               "name": "T",
-              "typeAnnotation": {
+              "bound": {
                 "type": "TypeAnnotation",
                 "start": 14,
                 "end": 23,

--- a/test/fixtures/flow/call-properties/4/expected.json
+++ b/test/fixtures/flow/call-properties/4/expected.json
@@ -212,7 +212,7 @@
                           },
                           "params": [
                             {
-                              "type": "Identifier",
+                              "type": "TypeParameter",
                               "start": 11,
                               "end": 12,
                               "loc": {
@@ -257,7 +257,7 @@
         ],
         "kind": "var"
       }
-    ]
-  },
-  "comments": []
+    ],
+    "directives": []
+  }
 }

--- a/test/fixtures/flow/declare-statements/14/expected.json
+++ b/test/fixtures/flow/declare-statements/14/expected.json
@@ -121,7 +121,7 @@
           },
           "params": [
             {
-              "type": "Identifier",
+              "type": "TypeParameter",
               "start": 40,
               "end": 41,
               "loc": {

--- a/test/fixtures/flow/declare-statements/15/expected.json
+++ b/test/fixtures/flow/declare-statements/15/expected.json
@@ -174,7 +174,7 @@
           },
           "params": [
             {
-              "type": "Identifier",
+              "type": "TypeParameter",
               "start": 56,
               "end": 57,
               "loc": {

--- a/test/fixtures/flow/declare-statements/5/expected.json
+++ b/test/fixtures/flow/declare-statements/5/expected.json
@@ -101,7 +101,7 @@
                 },
                 "params": [
                   {
-                    "type": "Identifier",
+                    "type": "TypeParameter",
                     "start": 21,
                     "end": 22,
                     "loc": {
@@ -139,7 +139,7 @@
           }
         }
       }
-    ]
-  },
-  "comments": []
+    ],
+    "directives": []
+  }
 }

--- a/test/fixtures/flow/declare-statements/9/expected.json
+++ b/test/fixtures/flow/declare-statements/9/expected.json
@@ -74,7 +74,7 @@
           },
           "params": [
             {
-              "type": "Identifier",
+              "type": "TypeParameter",
               "start": 16,
               "end": 17,
               "loc": {
@@ -173,6 +173,7 @@
             }
           }
         ],
+        "mixins": [],
         "body": {
           "type": "ObjectTypeAnnotation",
           "start": 32,
@@ -240,7 +241,7 @@
           "indexers": []
         }
       }
-    ]
-  },
-  "comments": []
+    ],
+    "directives": []
+  }
 }

--- a/test/fixtures/flow/def-site-variance/1/expected.json
+++ b/test/fixtures/flow/def-site-variance/1/expected.json
@@ -74,38 +74,38 @@
           },
           "params": [
             {
-              "type": "Identifier",
-              "start": 9,
+              "type": "TypeParameter",
+              "start": 8,
               "end": 10,
               "loc": {
                 "start": {
                   "line": 1,
-                  "column": 9
+                  "column": 8
                 },
                 "end": {
                   "line": 1,
                   "column": 10
                 }
               },
-              "name": "T",
-              "variance": "plus"
+              "variance": "plus",
+              "name": "T"
             },
             {
-              "type": "Identifier",
-              "start": 12,
+              "type": "TypeParameter",
+              "start": 11,
               "end": 13,
               "loc": {
                 "start": {
                   "line": 1,
-                  "column": 12
+                  "column": 11
                 },
                 "end": {
                   "line": 1,
                   "column": 13
                 }
               },
-              "name": "U",
-              "variance": "minus"
+              "variance": "minus",
+              "name": "U"
             }
           ]
         },
@@ -176,38 +176,38 @@
           },
           "params": [
             {
-              "type": "Identifier",
-              "start": 30,
+              "type": "TypeParameter",
+              "start": 29,
               "end": 31,
               "loc": {
                 "start": {
                   "line": 2,
-                  "column": 12
+                  "column": 11
                 },
                 "end": {
                   "line": 2,
                   "column": 13
                 }
               },
-              "name": "T",
-              "variance": "plus"
+              "variance": "plus",
+              "name": "T"
             },
             {
-              "type": "Identifier",
-              "start": 33,
+              "type": "TypeParameter",
+              "start": 32,
               "end": 34,
               "loc": {
                 "start": {
                   "line": 2,
-                  "column": 15
+                  "column": 14
                 },
                 "end": {
                   "line": 2,
                   "column": 16
                 }
               },
-              "name": "U",
-              "variance": "minus"
+              "variance": "minus",
+              "name": "U"
             }
           ]
         },
@@ -276,38 +276,38 @@
           },
           "params": [
             {
-              "type": "Identifier",
-              "start": 49,
+              "type": "TypeParameter",
+              "start": 48,
               "end": 50,
               "loc": {
                 "start": {
                   "line": 3,
-                  "column": 8
+                  "column": 7
                 },
                 "end": {
                   "line": 3,
                   "column": 9
                 }
               },
-              "name": "T",
-              "variance": "plus"
+              "variance": "plus",
+              "name": "T"
             },
             {
-              "type": "Identifier",
-              "start": 52,
+              "type": "TypeParameter",
+              "start": 51,
               "end": 53,
               "loc": {
                 "start": {
                   "line": 3,
-                  "column": 11
+                  "column": 10
                 },
                 "end": {
                   "line": 3,
                   "column": 12
                 }
               },
-              "name": "U",
-              "variance": "minus"
+              "variance": "minus",
+              "name": "U"
             }
           ]
         },

--- a/test/fixtures/flow/interfaces-module-and-script/3/expected.json
+++ b/test/fixtures/flow/interfaces-module-and-script/3/expected.json
@@ -74,7 +74,7 @@
           },
           "params": [
             {
-              "type": "Identifier",
+              "type": "TypeParameter",
               "start": 12,
               "end": 13,
               "loc": {
@@ -253,6 +253,7 @@
             }
           }
         ],
+        "mixins": [],
         "body": {
           "type": "ObjectTypeAnnotation",
           "start": 34,
@@ -272,7 +273,7 @@
           "indexers": []
         }
       }
-    ]
-  },
-  "comments": []
+    ],
+    "directives": []
+  }
 }

--- a/test/fixtures/flow/type-alias/2/expected.json
+++ b/test/fixtures/flow/type-alias/2/expected.json
@@ -74,7 +74,7 @@
           },
           "params": [
             {
-              "type": "Identifier",
+              "type": "TypeParameter",
               "start": 9,
               "end": 10,
               "loc": {
@@ -172,7 +172,7 @@
           }
         }
       }
-    ]
-  },
-  "comments": []
+    ],
+    "directives": []
+  }
 }

--- a/test/fixtures/flow/type-annotations/17/expected.json
+++ b/test/fixtures/flow/type-annotations/17/expected.json
@@ -60,6 +60,7 @@
         },
         "generator": false,
         "expression": false,
+        "async": false,
         "typeParameters": {
           "type": "TypeParameterDeclaration",
           "start": 12,
@@ -76,7 +77,7 @@
           },
           "params": [
             {
-              "type": "Identifier",
+              "type": "TypeParameter",
               "start": 13,
               "end": 14,
               "loc": {

--- a/test/fixtures/flow/type-annotations/18/expected.json
+++ b/test/fixtures/flow/type-annotations/18/expected.json
@@ -60,6 +60,7 @@
         },
         "generator": false,
         "expression": false,
+        "async": false,
         "typeParameters": {
           "type": "TypeParameterDeclaration",
           "start": 12,
@@ -76,7 +77,7 @@
           },
           "params": [
             {
-              "type": "Identifier",
+              "type": "TypeParameter",
               "start": 13,
               "end": 14,
               "loc": {
@@ -92,7 +93,7 @@
               "name": "T"
             },
             {
-              "type": "Identifier",
+              "type": "TypeParameter",
               "start": 15,
               "end": 16,
               "loc": {

--- a/test/fixtures/flow/type-annotations/19/expected.json
+++ b/test/fixtures/flow/type-annotations/19/expected.json
@@ -90,6 +90,7 @@
             "id": null,
             "generator": false,
             "expression": false,
+            "async": false,
             "typeParameters": {
               "type": "TypeParameterDeclaration",
               "start": 10,
@@ -106,7 +107,7 @@
               },
               "params": [
                 {
-                  "type": "Identifier",
+                  "type": "TypeParameter",
                   "start": 11,
                   "end": 12,
                   "loc": {
@@ -122,7 +123,7 @@
                   "name": "T"
                 },
                 {
-                  "type": "Identifier",
+                  "type": "TypeParameter",
                   "start": 13,
                   "end": 14,
                   "loc": {

--- a/test/fixtures/flow/type-annotations/23/expected.json
+++ b/test/fixtures/flow/type-annotations/23/expected.json
@@ -271,7 +271,7 @@
                   },
                   "params": [
                     {
-                      "type": "Identifier",
+                      "type": "TypeParameter",
                       "start": 6,
                       "end": 7,
                       "loc": {

--- a/test/fixtures/flow/type-annotations/24/expected.json
+++ b/test/fixtures/flow/type-annotations/24/expected.json
@@ -271,7 +271,7 @@
                   },
                   "params": [
                     {
-                      "type": "Identifier",
+                      "type": "TypeParameter",
                       "start": 7,
                       "end": 8,
                       "loc": {

--- a/test/fixtures/flow/type-annotations/25/expected.json
+++ b/test/fixtures/flow/type-annotations/25/expected.json
@@ -271,7 +271,7 @@
                   },
                   "params": [
                     {
-                      "type": "Identifier",
+                      "type": "TypeParameter",
                       "start": 12,
                       "end": 13,
                       "loc": {

--- a/test/fixtures/flow/type-annotations/26/expected.json
+++ b/test/fixtures/flow/type-annotations/26/expected.json
@@ -275,7 +275,7 @@
                   },
                   "params": [
                     {
-                      "type": "Identifier",
+                      "type": "TypeParameter",
                       "start": 7,
                       "end": 8,
                       "loc": {

--- a/test/fixtures/flow/type-annotations/43/expected.json
+++ b/test/fixtures/flow/type-annotations/43/expected.json
@@ -213,7 +213,7 @@
                           },
                           "params": [
                             {
-                              "type": "Identifier",
+                              "type": "TypeParameter",
                               "start": 12,
                               "end": 13,
                               "loc": {
@@ -291,7 +291,7 @@
         ],
         "kind": "var"
       }
-    ]
-  },
-  "comments": []
+    ],
+    "directives": []
+  }
 }

--- a/test/fixtures/flow/type-annotations/45/expected.json
+++ b/test/fixtures/flow/type-annotations/45/expected.json
@@ -119,7 +119,7 @@
               },
               "params": [
                 {
-                  "type": "Identifier",
+                  "type": "TypeParameter",
                   "start": 14,
                   "end": 15,
                   "loc": {
@@ -156,7 +156,7 @@
           }
         }
       }
-    ]
-  },
-  "comments": []
+    ],
+    "directives": []
+  }
 }

--- a/test/fixtures/flow/type-annotations/46/expected.json
+++ b/test/fixtures/flow/type-annotations/46/expected.json
@@ -119,7 +119,7 @@
               },
               "params": [
                 {
-                  "type": "Identifier",
+                  "type": "TypeParameter",
                   "start": 14,
                   "end": 15,
                   "loc": {
@@ -220,7 +220,7 @@
           }
         }
       }
-    ]
-  },
-  "comments": []
+    ],
+    "directives": []
+  }
 }

--- a/test/fixtures/flow/type-annotations/47/expected.json
+++ b/test/fixtures/flow/type-annotations/47/expected.json
@@ -74,7 +74,7 @@
           },
           "params": [
             {
-              "type": "Identifier",
+              "type": "TypeParameter",
               "start": 10,
               "end": 11,
               "loc": {
@@ -109,7 +109,7 @@
           "body": []
         }
       }
-    ]
-  },
-  "comments": []
+    ],
+    "directives": []
+  }
 }

--- a/test/fixtures/flow/type-annotations/48/expected.json
+++ b/test/fixtures/flow/type-annotations/48/expected.json
@@ -74,7 +74,7 @@
           },
           "params": [
             {
-              "type": "Identifier",
+              "type": "TypeParameter",
               "start": 10,
               "end": 11,
               "loc": {
@@ -173,7 +173,7 @@
           "body": []
         }
       }
-    ]
-  },
-  "comments": []
+    ],
+    "directives": []
+  }
 }

--- a/test/fixtures/flow/type-annotations/49/expected.json
+++ b/test/fixtures/flow/type-annotations/49/expected.json
@@ -74,7 +74,7 @@
           },
           "params": [
             {
-              "type": "Identifier",
+              "type": "TypeParameter",
               "start": 10,
               "end": 11,
               "loc": {
@@ -157,7 +157,7 @@
           "body": []
         }
       }
-    ]
-  },
-  "comments": []
+    ],
+    "directives": []
+  }
 }

--- a/test/fixtures/flow/type-annotations/50/expected.json
+++ b/test/fixtures/flow/type-annotations/50/expected.json
@@ -74,7 +74,7 @@
           },
           "params": [
             {
-              "type": "Identifier",
+              "type": "TypeParameter",
               "start": 10,
               "end": 11,
               "loc": {
@@ -156,7 +156,7 @@
                 },
                 "params": [
                   {
-                    "type": "Identifier",
+                    "type": "TypeParameter",
                     "start": 19,
                     "end": 20,
                     "loc": {

--- a/test/fixtures/flow/type-annotations/51/expected.json
+++ b/test/fixtures/flow/type-annotations/51/expected.json
@@ -127,7 +127,7 @@
                 },
                 "params": [
                   {
-                    "type": "Identifier",
+                    "type": "TypeParameter",
                     "start": 18,
                     "end": 19,
                     "loc": {

--- a/test/fixtures/flow/type-annotations/87/expected.json
+++ b/test/fixtures/flow/type-annotations/87/expected.json
@@ -116,7 +116,7 @@
                     },
                     "params": [
                       {
-                        "type": "Identifier",
+                        "type": "TypeParameter",
                         "start": 15,
                         "end": 16,
                         "loc": {
@@ -240,7 +240,7 @@
         ],
         "kind": "var"
       }
-    ]
-  },
-  "comments": []
+    ],
+    "directives": []
+  }
 }

--- a/test/fixtures/flow/type-annotations/88/expected.json
+++ b/test/fixtures/flow/type-annotations/88/expected.json
@@ -116,7 +116,7 @@
                     },
                     "params": [
                       {
-                        "type": "Identifier",
+                        "type": "TypeParameter",
                         "start": 15,
                         "end": 16,
                         "loc": {
@@ -318,7 +318,7 @@
         ],
         "kind": "var"
       }
-    ]
-  },
-  "comments": []
+    ],
+    "directives": []
+  }
 }

--- a/test/fixtures/flow/type-annotations/97/expected.json
+++ b/test/fixtures/flow/type-annotations/97/expected.json
@@ -124,7 +124,7 @@
                   },
                   "params": [
                     {
-                      "type": "Identifier",
+                      "type": "TypeParameter",
                       "start": 15,
                       "end": 16,
                       "loc": {
@@ -163,7 +163,8 @@
             }
           ],
           "extra": {
-            "parenthesized": true
+            "parenthesized": true,
+            "parenStart": 0
           }
         }
       }

--- a/test/fixtures/flow/type-annotations/existential-type-param/expected.json
+++ b/test/fixtures/flow/type-annotations/existential-type-param/expected.json
@@ -74,7 +74,7 @@
           },
           "params": [
             {
-              "type": "Identifier",
+              "type": "TypeParameter",
               "start": 11,
               "end": 12,
               "loc": {

--- a/test/fixtures/flow/type-exports/interface/expected.json
+++ b/test/fixtures/flow/type-exports/interface/expected.json
@@ -224,7 +224,7 @@
             },
             "params": [
               {
-                "type": "Identifier",
+                "type": "TypeParameter",
                 "start": 57,
                 "end": 58,
                 "loc": {

--- a/test/fixtures/flow/type-parameter-declaration/default/actual.js
+++ b/test/fixtures/flow/type-parameter-declaration/default/actual.js
@@ -1,0 +1,21 @@
+type A<T = string> = T
+type A<T = *> = T
+type A<T: ?string = string> = T
+type A<S, T: ?string = string> = T
+type A<S = number, T: ?string = string> = T
+class A<T = string> {}
+class A<T: ?string = string> {}
+class A<S, T: ?string = string> {}
+class A<S = number, T: ?string = string> {}
+(class A<T = string> {})
+(class A<T: ?string = string> {})
+(class A<S, T: ?string = string> {})
+(class A<S = number, T: ?string = string> {})
+declare class A<T = string> {}
+declare class A<T: ?string = string> {}
+declare class A<S, T: ?string = string> {}
+declare class A<S = number, T: ?string = string> {}
+interface A<T = string> {}
+interface A<T: ?string = string> {}
+interface A<S, T: ?string = string> {}
+interface A<S = number, T: ?string = string> {}

--- a/test/fixtures/flow/type-parameter-declaration/default/expected.json
+++ b/test/fixtures/flow/type-parameter-declaration/default/expected.json
@@ -1,0 +1,3129 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 743,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 21,
+      "column": 47
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 743,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 21,
+        "column": 47
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "TypeAlias",
+        "start": 0,
+        "end": 22,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 22
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 5,
+          "end": 6,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 5
+            },
+            "end": {
+              "line": 1,
+              "column": 6
+            }
+          },
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 6,
+          "end": 18,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 18
+            }
+          },
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start": 7,
+              "end": 17,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 7
+                },
+                "end": {
+                  "line": 1,
+                  "column": 17
+                }
+              },
+              "name": "T",
+              "default": {
+                "type": "StringTypeAnnotation",
+                "start": 11,
+                "end": 17,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 17
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "right": {
+          "type": "GenericTypeAnnotation",
+          "start": 21,
+          "end": 22,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 21
+            },
+            "end": {
+              "line": 1,
+              "column": 22
+            }
+          },
+          "typeParameters": null,
+          "id": {
+            "type": "Identifier",
+            "start": 21,
+            "end": 22,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 21
+              },
+              "end": {
+                "line": 1,
+                "column": 22
+              }
+            },
+            "name": "T"
+          }
+        }
+      },
+      {
+        "type": "TypeAlias",
+        "start": 23,
+        "end": 40,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 17
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 28,
+          "end": 29,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 5
+            },
+            "end": {
+              "line": 2,
+              "column": 6
+            }
+          },
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 29,
+          "end": 36,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 6
+            },
+            "end": {
+              "line": 2,
+              "column": 13
+            }
+          },
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start": 30,
+              "end": 35,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 7
+                },
+                "end": {
+                  "line": 2,
+                  "column": 12
+                }
+              },
+              "name": "T",
+              "default": {
+                "type": "ExistentialTypeParam",
+                "start": 34,
+                "end": 35,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 12
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "right": {
+          "type": "GenericTypeAnnotation",
+          "start": 39,
+          "end": 40,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 16
+            },
+            "end": {
+              "line": 2,
+              "column": 17
+            }
+          },
+          "typeParameters": null,
+          "id": {
+            "type": "Identifier",
+            "start": 39,
+            "end": 40,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 16
+              },
+              "end": {
+                "line": 2,
+                "column": 17
+              }
+            },
+            "name": "T"
+          }
+        }
+      },
+      {
+        "type": "TypeAlias",
+        "start": 41,
+        "end": 72,
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 31
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 46,
+          "end": 47,
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 5
+            },
+            "end": {
+              "line": 3,
+              "column": 6
+            }
+          },
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 47,
+          "end": 68,
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 6
+            },
+            "end": {
+              "line": 3,
+              "column": 27
+            }
+          },
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start": 48,
+              "end": 67,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 7
+                },
+                "end": {
+                  "line": 3,
+                  "column": 26
+                }
+              },
+              "name": "T",
+              "bound": {
+                "type": "TypeAnnotation",
+                "start": 49,
+                "end": 58,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 8
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 17
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "NullableTypeAnnotation",
+                  "start": 51,
+                  "end": 58,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 10
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 17
+                    }
+                  },
+                  "typeAnnotation": {
+                    "type": "StringTypeAnnotation",
+                    "start": 52,
+                    "end": 58,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 11
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 17
+                      }
+                    }
+                  }
+                }
+              },
+              "default": {
+                "type": "StringTypeAnnotation",
+                "start": 61,
+                "end": 67,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 20
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 26
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "right": {
+          "type": "GenericTypeAnnotation",
+          "start": 71,
+          "end": 72,
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 30
+            },
+            "end": {
+              "line": 3,
+              "column": 31
+            }
+          },
+          "typeParameters": null,
+          "id": {
+            "type": "Identifier",
+            "start": 71,
+            "end": 72,
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 30
+              },
+              "end": {
+                "line": 3,
+                "column": 31
+              }
+            },
+            "name": "T"
+          }
+        }
+      },
+      {
+        "type": "TypeAlias",
+        "start": 73,
+        "end": 107,
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 34
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 78,
+          "end": 79,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 5
+            },
+            "end": {
+              "line": 4,
+              "column": 6
+            }
+          },
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 79,
+          "end": 103,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 6
+            },
+            "end": {
+              "line": 4,
+              "column": 30
+            }
+          },
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start": 80,
+              "end": 81,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 7
+                },
+                "end": {
+                  "line": 4,
+                  "column": 8
+                }
+              },
+              "name": "S"
+            },
+            {
+              "type": "TypeParameter",
+              "start": 83,
+              "end": 102,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 10
+                },
+                "end": {
+                  "line": 4,
+                  "column": 29
+                }
+              },
+              "name": "T",
+              "bound": {
+                "type": "TypeAnnotation",
+                "start": 84,
+                "end": 93,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 20
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "NullableTypeAnnotation",
+                  "start": 86,
+                  "end": 93,
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 13
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 20
+                    }
+                  },
+                  "typeAnnotation": {
+                    "type": "StringTypeAnnotation",
+                    "start": 87,
+                    "end": 93,
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 14
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 20
+                      }
+                    }
+                  }
+                }
+              },
+              "default": {
+                "type": "StringTypeAnnotation",
+                "start": 96,
+                "end": 102,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 23
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 29
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "right": {
+          "type": "GenericTypeAnnotation",
+          "start": 106,
+          "end": 107,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 33
+            },
+            "end": {
+              "line": 4,
+              "column": 34
+            }
+          },
+          "typeParameters": null,
+          "id": {
+            "type": "Identifier",
+            "start": 106,
+            "end": 107,
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 33
+              },
+              "end": {
+                "line": 4,
+                "column": 34
+              }
+            },
+            "name": "T"
+          }
+        }
+      },
+      {
+        "type": "TypeAlias",
+        "start": 108,
+        "end": 151,
+        "loc": {
+          "start": {
+            "line": 5,
+            "column": 0
+          },
+          "end": {
+            "line": 5,
+            "column": 43
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 113,
+          "end": 114,
+          "loc": {
+            "start": {
+              "line": 5,
+              "column": 5
+            },
+            "end": {
+              "line": 5,
+              "column": 6
+            }
+          },
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 114,
+          "end": 147,
+          "loc": {
+            "start": {
+              "line": 5,
+              "column": 6
+            },
+            "end": {
+              "line": 5,
+              "column": 39
+            }
+          },
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start": 115,
+              "end": 125,
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 7
+                },
+                "end": {
+                  "line": 5,
+                  "column": 17
+                }
+              },
+              "name": "S",
+              "default": {
+                "type": "NumberTypeAnnotation",
+                "start": 119,
+                "end": 125,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 17
+                  }
+                }
+              }
+            },
+            {
+              "type": "TypeParameter",
+              "start": 127,
+              "end": 146,
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 19
+                },
+                "end": {
+                  "line": 5,
+                  "column": 38
+                }
+              },
+              "name": "T",
+              "bound": {
+                "type": "TypeAnnotation",
+                "start": 128,
+                "end": 137,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 20
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 29
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "NullableTypeAnnotation",
+                  "start": 130,
+                  "end": 137,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 22
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 29
+                    }
+                  },
+                  "typeAnnotation": {
+                    "type": "StringTypeAnnotation",
+                    "start": 131,
+                    "end": 137,
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 23
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 29
+                      }
+                    }
+                  }
+                }
+              },
+              "default": {
+                "type": "StringTypeAnnotation",
+                "start": 140,
+                "end": 146,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 32
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 38
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "right": {
+          "type": "GenericTypeAnnotation",
+          "start": 150,
+          "end": 151,
+          "loc": {
+            "start": {
+              "line": 5,
+              "column": 42
+            },
+            "end": {
+              "line": 5,
+              "column": 43
+            }
+          },
+          "typeParameters": null,
+          "id": {
+            "type": "Identifier",
+            "start": 150,
+            "end": 151,
+            "loc": {
+              "start": {
+                "line": 5,
+                "column": 42
+              },
+              "end": {
+                "line": 5,
+                "column": 43
+              }
+            },
+            "name": "T"
+          }
+        }
+      },
+      {
+        "type": "ClassDeclaration",
+        "start": 152,
+        "end": 174,
+        "loc": {
+          "start": {
+            "line": 6,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 22
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 158,
+          "end": 159,
+          "loc": {
+            "start": {
+              "line": 6,
+              "column": 6
+            },
+            "end": {
+              "line": 6,
+              "column": 7
+            }
+          },
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 159,
+          "end": 171,
+          "loc": {
+            "start": {
+              "line": 6,
+              "column": 7
+            },
+            "end": {
+              "line": 6,
+              "column": 19
+            }
+          },
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start": 160,
+              "end": 170,
+              "loc": {
+                "start": {
+                  "line": 6,
+                  "column": 8
+                },
+                "end": {
+                  "line": 6,
+                  "column": 18
+                }
+              },
+              "name": "T",
+              "default": {
+                "type": "StringTypeAnnotation",
+                "start": 164,
+                "end": 170,
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 18
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 172,
+          "end": 174,
+          "loc": {
+            "start": {
+              "line": 6,
+              "column": 20
+            },
+            "end": {
+              "line": 6,
+              "column": 22
+            }
+          },
+          "body": []
+        }
+      },
+      {
+        "type": "ClassDeclaration",
+        "start": 175,
+        "end": 206,
+        "loc": {
+          "start": {
+            "line": 7,
+            "column": 0
+          },
+          "end": {
+            "line": 7,
+            "column": 31
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 181,
+          "end": 182,
+          "loc": {
+            "start": {
+              "line": 7,
+              "column": 6
+            },
+            "end": {
+              "line": 7,
+              "column": 7
+            }
+          },
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 182,
+          "end": 203,
+          "loc": {
+            "start": {
+              "line": 7,
+              "column": 7
+            },
+            "end": {
+              "line": 7,
+              "column": 28
+            }
+          },
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start": 183,
+              "end": 202,
+              "loc": {
+                "start": {
+                  "line": 7,
+                  "column": 8
+                },
+                "end": {
+                  "line": 7,
+                  "column": 27
+                }
+              },
+              "name": "T",
+              "bound": {
+                "type": "TypeAnnotation",
+                "start": 184,
+                "end": 193,
+                "loc": {
+                  "start": {
+                    "line": 7,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 7,
+                    "column": 18
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "NullableTypeAnnotation",
+                  "start": 186,
+                  "end": 193,
+                  "loc": {
+                    "start": {
+                      "line": 7,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 7,
+                      "column": 18
+                    }
+                  },
+                  "typeAnnotation": {
+                    "type": "StringTypeAnnotation",
+                    "start": 187,
+                    "end": 193,
+                    "loc": {
+                      "start": {
+                        "line": 7,
+                        "column": 12
+                      },
+                      "end": {
+                        "line": 7,
+                        "column": 18
+                      }
+                    }
+                  }
+                }
+              },
+              "default": {
+                "type": "StringTypeAnnotation",
+                "start": 196,
+                "end": 202,
+                "loc": {
+                  "start": {
+                    "line": 7,
+                    "column": 21
+                  },
+                  "end": {
+                    "line": 7,
+                    "column": 27
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 204,
+          "end": 206,
+          "loc": {
+            "start": {
+              "line": 7,
+              "column": 29
+            },
+            "end": {
+              "line": 7,
+              "column": 31
+            }
+          },
+          "body": []
+        }
+      },
+      {
+        "type": "ClassDeclaration",
+        "start": 207,
+        "end": 241,
+        "loc": {
+          "start": {
+            "line": 8,
+            "column": 0
+          },
+          "end": {
+            "line": 8,
+            "column": 34
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 213,
+          "end": 214,
+          "loc": {
+            "start": {
+              "line": 8,
+              "column": 6
+            },
+            "end": {
+              "line": 8,
+              "column": 7
+            }
+          },
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 214,
+          "end": 238,
+          "loc": {
+            "start": {
+              "line": 8,
+              "column": 7
+            },
+            "end": {
+              "line": 8,
+              "column": 31
+            }
+          },
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start": 215,
+              "end": 216,
+              "loc": {
+                "start": {
+                  "line": 8,
+                  "column": 8
+                },
+                "end": {
+                  "line": 8,
+                  "column": 9
+                }
+              },
+              "name": "S"
+            },
+            {
+              "type": "TypeParameter",
+              "start": 218,
+              "end": 237,
+              "loc": {
+                "start": {
+                  "line": 8,
+                  "column": 11
+                },
+                "end": {
+                  "line": 8,
+                  "column": 30
+                }
+              },
+              "name": "T",
+              "bound": {
+                "type": "TypeAnnotation",
+                "start": 219,
+                "end": 228,
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 21
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "NullableTypeAnnotation",
+                  "start": 221,
+                  "end": 228,
+                  "loc": {
+                    "start": {
+                      "line": 8,
+                      "column": 14
+                    },
+                    "end": {
+                      "line": 8,
+                      "column": 21
+                    }
+                  },
+                  "typeAnnotation": {
+                    "type": "StringTypeAnnotation",
+                    "start": 222,
+                    "end": 228,
+                    "loc": {
+                      "start": {
+                        "line": 8,
+                        "column": 15
+                      },
+                      "end": {
+                        "line": 8,
+                        "column": 21
+                      }
+                    }
+                  }
+                }
+              },
+              "default": {
+                "type": "StringTypeAnnotation",
+                "start": 231,
+                "end": 237,
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 24
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 30
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 239,
+          "end": 241,
+          "loc": {
+            "start": {
+              "line": 8,
+              "column": 32
+            },
+            "end": {
+              "line": 8,
+              "column": 34
+            }
+          },
+          "body": []
+        }
+      },
+      {
+        "type": "ClassDeclaration",
+        "start": 242,
+        "end": 285,
+        "loc": {
+          "start": {
+            "line": 9,
+            "column": 0
+          },
+          "end": {
+            "line": 9,
+            "column": 43
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 248,
+          "end": 249,
+          "loc": {
+            "start": {
+              "line": 9,
+              "column": 6
+            },
+            "end": {
+              "line": 9,
+              "column": 7
+            }
+          },
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 249,
+          "end": 282,
+          "loc": {
+            "start": {
+              "line": 9,
+              "column": 7
+            },
+            "end": {
+              "line": 9,
+              "column": 40
+            }
+          },
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start": 250,
+              "end": 260,
+              "loc": {
+                "start": {
+                  "line": 9,
+                  "column": 8
+                },
+                "end": {
+                  "line": 9,
+                  "column": 18
+                }
+              },
+              "name": "S",
+              "default": {
+                "type": "NumberTypeAnnotation",
+                "start": 254,
+                "end": 260,
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 18
+                  }
+                }
+              }
+            },
+            {
+              "type": "TypeParameter",
+              "start": 262,
+              "end": 281,
+              "loc": {
+                "start": {
+                  "line": 9,
+                  "column": 20
+                },
+                "end": {
+                  "line": 9,
+                  "column": 39
+                }
+              },
+              "name": "T",
+              "bound": {
+                "type": "TypeAnnotation",
+                "start": 263,
+                "end": 272,
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 21
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 30
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "NullableTypeAnnotation",
+                  "start": 265,
+                  "end": 272,
+                  "loc": {
+                    "start": {
+                      "line": 9,
+                      "column": 23
+                    },
+                    "end": {
+                      "line": 9,
+                      "column": 30
+                    }
+                  },
+                  "typeAnnotation": {
+                    "type": "StringTypeAnnotation",
+                    "start": 266,
+                    "end": 272,
+                    "loc": {
+                      "start": {
+                        "line": 9,
+                        "column": 24
+                      },
+                      "end": {
+                        "line": 9,
+                        "column": 30
+                      }
+                    }
+                  }
+                }
+              },
+              "default": {
+                "type": "StringTypeAnnotation",
+                "start": 275,
+                "end": 281,
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 33
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 39
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 283,
+          "end": 285,
+          "loc": {
+            "start": {
+              "line": 9,
+              "column": 41
+            },
+            "end": {
+              "line": 9,
+              "column": 43
+            }
+          },
+          "body": []
+        }
+      },
+      {
+        "type": "ExpressionStatement",
+        "start": 286,
+        "end": 427,
+        "loc": {
+          "start": {
+            "line": 10,
+            "column": 0
+          },
+          "end": {
+            "line": 13,
+            "column": 45
+          }
+        },
+        "expression": {
+          "type": "CallExpression",
+          "start": 286,
+          "end": 427,
+          "loc": {
+            "start": {
+              "line": 10,
+              "column": 0
+            },
+            "end": {
+              "line": 13,
+              "column": 45
+            }
+          },
+          "callee": {
+            "type": "CallExpression",
+            "start": 286,
+            "end": 381,
+            "loc": {
+              "start": {
+                "line": 10,
+                "column": 0
+              },
+              "end": {
+                "line": 12,
+                "column": 36
+              }
+            },
+            "callee": {
+              "type": "CallExpression",
+              "start": 286,
+              "end": 344,
+              "loc": {
+                "start": {
+                  "line": 10,
+                  "column": 0
+                },
+                "end": {
+                  "line": 11,
+                  "column": 33
+                }
+              },
+              "callee": {
+                "type": "ClassExpression",
+                "start": 287,
+                "end": 309,
+                "loc": {
+                  "start": {
+                    "line": 10,
+                    "column": 1
+                  },
+                  "end": {
+                    "line": 10,
+                    "column": 23
+                  }
+                },
+                "id": {
+                  "type": "Identifier",
+                  "start": 293,
+                  "end": 294,
+                  "loc": {
+                    "start": {
+                      "line": 10,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 10,
+                      "column": 8
+                    }
+                  },
+                  "name": "A"
+                },
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 294,
+                  "end": 306,
+                  "loc": {
+                    "start": {
+                      "line": 10,
+                      "column": 8
+                    },
+                    "end": {
+                      "line": 10,
+                      "column": 20
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 295,
+                      "end": 305,
+                      "loc": {
+                        "start": {
+                          "line": 10,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 10,
+                          "column": 19
+                        }
+                      },
+                      "name": "T",
+                      "default": {
+                        "type": "StringTypeAnnotation",
+                        "start": 299,
+                        "end": 305,
+                        "loc": {
+                          "start": {
+                            "line": 10,
+                            "column": 13
+                          },
+                          "end": {
+                            "line": 10,
+                            "column": 19
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                "superClass": null,
+                "body": {
+                  "type": "ClassBody",
+                  "start": 307,
+                  "end": 309,
+                  "loc": {
+                    "start": {
+                      "line": 10,
+                      "column": 21
+                    },
+                    "end": {
+                      "line": 10,
+                      "column": 23
+                    }
+                  },
+                  "body": []
+                },
+                "extra": {
+                  "parenthesized": true,
+                  "parenStart": 286
+                }
+              },
+              "arguments": [
+                {
+                  "type": "ClassExpression",
+                  "start": 312,
+                  "end": 343,
+                  "loc": {
+                    "start": {
+                      "line": 11,
+                      "column": 1
+                    },
+                    "end": {
+                      "line": 11,
+                      "column": 32
+                    }
+                  },
+                  "id": {
+                    "type": "Identifier",
+                    "start": 318,
+                    "end": 319,
+                    "loc": {
+                      "start": {
+                        "line": 11,
+                        "column": 7
+                      },
+                      "end": {
+                        "line": 11,
+                        "column": 8
+                      }
+                    },
+                    "name": "A"
+                  },
+                  "typeParameters": {
+                    "type": "TypeParameterDeclaration",
+                    "start": 319,
+                    "end": 340,
+                    "loc": {
+                      "start": {
+                        "line": 11,
+                        "column": 8
+                      },
+                      "end": {
+                        "line": 11,
+                        "column": 29
+                      }
+                    },
+                    "params": [
+                      {
+                        "type": "TypeParameter",
+                        "start": 320,
+                        "end": 339,
+                        "loc": {
+                          "start": {
+                            "line": 11,
+                            "column": 9
+                          },
+                          "end": {
+                            "line": 11,
+                            "column": 28
+                          }
+                        },
+                        "name": "T",
+                        "bound": {
+                          "type": "TypeAnnotation",
+                          "start": 321,
+                          "end": 330,
+                          "loc": {
+                            "start": {
+                              "line": 11,
+                              "column": 10
+                            },
+                            "end": {
+                              "line": 11,
+                              "column": 19
+                            }
+                          },
+                          "typeAnnotation": {
+                            "type": "NullableTypeAnnotation",
+                            "start": 323,
+                            "end": 330,
+                            "loc": {
+                              "start": {
+                                "line": 11,
+                                "column": 12
+                              },
+                              "end": {
+                                "line": 11,
+                                "column": 19
+                              }
+                            },
+                            "typeAnnotation": {
+                              "type": "StringTypeAnnotation",
+                              "start": 324,
+                              "end": 330,
+                              "loc": {
+                                "start": {
+                                  "line": 11,
+                                  "column": 13
+                                },
+                                "end": {
+                                  "line": 11,
+                                  "column": 19
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "default": {
+                          "type": "StringTypeAnnotation",
+                          "start": 333,
+                          "end": 339,
+                          "loc": {
+                            "start": {
+                              "line": 11,
+                              "column": 22
+                            },
+                            "end": {
+                              "line": 11,
+                              "column": 28
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "superClass": null,
+                  "body": {
+                    "type": "ClassBody",
+                    "start": 341,
+                    "end": 343,
+                    "loc": {
+                      "start": {
+                        "line": 11,
+                        "column": 30
+                      },
+                      "end": {
+                        "line": 11,
+                        "column": 32
+                      }
+                    },
+                    "body": []
+                  }
+                }
+              ]
+            },
+            "arguments": [
+              {
+                "type": "ClassExpression",
+                "start": 346,
+                "end": 380,
+                "loc": {
+                  "start": {
+                    "line": 12,
+                    "column": 1
+                  },
+                  "end": {
+                    "line": 12,
+                    "column": 35
+                  }
+                },
+                "id": {
+                  "type": "Identifier",
+                  "start": 352,
+                  "end": 353,
+                  "loc": {
+                    "start": {
+                      "line": 12,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 12,
+                      "column": 8
+                    }
+                  },
+                  "name": "A"
+                },
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 353,
+                  "end": 377,
+                  "loc": {
+                    "start": {
+                      "line": 12,
+                      "column": 8
+                    },
+                    "end": {
+                      "line": 12,
+                      "column": 32
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 354,
+                      "end": 355,
+                      "loc": {
+                        "start": {
+                          "line": 12,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 12,
+                          "column": 10
+                        }
+                      },
+                      "name": "S"
+                    },
+                    {
+                      "type": "TypeParameter",
+                      "start": 357,
+                      "end": 376,
+                      "loc": {
+                        "start": {
+                          "line": 12,
+                          "column": 12
+                        },
+                        "end": {
+                          "line": 12,
+                          "column": 31
+                        }
+                      },
+                      "name": "T",
+                      "bound": {
+                        "type": "TypeAnnotation",
+                        "start": 358,
+                        "end": 367,
+                        "loc": {
+                          "start": {
+                            "line": 12,
+                            "column": 13
+                          },
+                          "end": {
+                            "line": 12,
+                            "column": 22
+                          }
+                        },
+                        "typeAnnotation": {
+                          "type": "NullableTypeAnnotation",
+                          "start": 360,
+                          "end": 367,
+                          "loc": {
+                            "start": {
+                              "line": 12,
+                              "column": 15
+                            },
+                            "end": {
+                              "line": 12,
+                              "column": 22
+                            }
+                          },
+                          "typeAnnotation": {
+                            "type": "StringTypeAnnotation",
+                            "start": 361,
+                            "end": 367,
+                            "loc": {
+                              "start": {
+                                "line": 12,
+                                "column": 16
+                              },
+                              "end": {
+                                "line": 12,
+                                "column": 22
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "default": {
+                        "type": "StringTypeAnnotation",
+                        "start": 370,
+                        "end": 376,
+                        "loc": {
+                          "start": {
+                            "line": 12,
+                            "column": 25
+                          },
+                          "end": {
+                            "line": 12,
+                            "column": 31
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                "superClass": null,
+                "body": {
+                  "type": "ClassBody",
+                  "start": 378,
+                  "end": 380,
+                  "loc": {
+                    "start": {
+                      "line": 12,
+                      "column": 33
+                    },
+                    "end": {
+                      "line": 12,
+                      "column": 35
+                    }
+                  },
+                  "body": []
+                }
+              }
+            ]
+          },
+          "arguments": [
+            {
+              "type": "ClassExpression",
+              "start": 383,
+              "end": 426,
+              "loc": {
+                "start": {
+                  "line": 13,
+                  "column": 1
+                },
+                "end": {
+                  "line": 13,
+                  "column": 44
+                }
+              },
+              "id": {
+                "type": "Identifier",
+                "start": 389,
+                "end": 390,
+                "loc": {
+                  "start": {
+                    "line": 13,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 13,
+                    "column": 8
+                  }
+                },
+                "name": "A"
+              },
+              "typeParameters": {
+                "type": "TypeParameterDeclaration",
+                "start": 390,
+                "end": 423,
+                "loc": {
+                  "start": {
+                    "line": 13,
+                    "column": 8
+                  },
+                  "end": {
+                    "line": 13,
+                    "column": 41
+                  }
+                },
+                "params": [
+                  {
+                    "type": "TypeParameter",
+                    "start": 391,
+                    "end": 401,
+                    "loc": {
+                      "start": {
+                        "line": 13,
+                        "column": 9
+                      },
+                      "end": {
+                        "line": 13,
+                        "column": 19
+                      }
+                    },
+                    "name": "S",
+                    "default": {
+                      "type": "NumberTypeAnnotation",
+                      "start": 395,
+                      "end": 401,
+                      "loc": {
+                        "start": {
+                          "line": 13,
+                          "column": 13
+                        },
+                        "end": {
+                          "line": 13,
+                          "column": 19
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "TypeParameter",
+                    "start": 403,
+                    "end": 422,
+                    "loc": {
+                      "start": {
+                        "line": 13,
+                        "column": 21
+                      },
+                      "end": {
+                        "line": 13,
+                        "column": 40
+                      }
+                    },
+                    "name": "T",
+                    "bound": {
+                      "type": "TypeAnnotation",
+                      "start": 404,
+                      "end": 413,
+                      "loc": {
+                        "start": {
+                          "line": 13,
+                          "column": 22
+                        },
+                        "end": {
+                          "line": 13,
+                          "column": 31
+                        }
+                      },
+                      "typeAnnotation": {
+                        "type": "NullableTypeAnnotation",
+                        "start": 406,
+                        "end": 413,
+                        "loc": {
+                          "start": {
+                            "line": 13,
+                            "column": 24
+                          },
+                          "end": {
+                            "line": 13,
+                            "column": 31
+                          }
+                        },
+                        "typeAnnotation": {
+                          "type": "StringTypeAnnotation",
+                          "start": 407,
+                          "end": 413,
+                          "loc": {
+                            "start": {
+                              "line": 13,
+                              "column": 25
+                            },
+                            "end": {
+                              "line": 13,
+                              "column": 31
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "default": {
+                      "type": "StringTypeAnnotation",
+                      "start": 416,
+                      "end": 422,
+                      "loc": {
+                        "start": {
+                          "line": 13,
+                          "column": 34
+                        },
+                        "end": {
+                          "line": 13,
+                          "column": 40
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              "superClass": null,
+              "body": {
+                "type": "ClassBody",
+                "start": 424,
+                "end": 426,
+                "loc": {
+                  "start": {
+                    "line": 13,
+                    "column": 42
+                  },
+                  "end": {
+                    "line": 13,
+                    "column": 44
+                  }
+                },
+                "body": []
+              }
+            }
+          ]
+        }
+      },
+      {
+        "type": "DeclareClass",
+        "start": 428,
+        "end": 458,
+        "loc": {
+          "start": {
+            "line": 14,
+            "column": 0
+          },
+          "end": {
+            "line": 14,
+            "column": 30
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 442,
+          "end": 443,
+          "loc": {
+            "start": {
+              "line": 14,
+              "column": 14
+            },
+            "end": {
+              "line": 14,
+              "column": 15
+            }
+          },
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 443,
+          "end": 455,
+          "loc": {
+            "start": {
+              "line": 14,
+              "column": 15
+            },
+            "end": {
+              "line": 14,
+              "column": 27
+            }
+          },
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start": 444,
+              "end": 454,
+              "loc": {
+                "start": {
+                  "line": 14,
+                  "column": 16
+                },
+                "end": {
+                  "line": 14,
+                  "column": 26
+                }
+              },
+              "name": "T",
+              "default": {
+                "type": "StringTypeAnnotation",
+                "start": 448,
+                "end": 454,
+                "loc": {
+                  "start": {
+                    "line": 14,
+                    "column": 20
+                  },
+                  "end": {
+                    "line": 14,
+                    "column": 26
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "extends": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 456,
+          "end": 458,
+          "loc": {
+            "start": {
+              "line": 14,
+              "column": 28
+            },
+            "end": {
+              "line": 14,
+              "column": 30
+            }
+          },
+          "callProperties": [],
+          "properties": [],
+          "indexers": []
+        }
+      },
+      {
+        "type": "DeclareClass",
+        "start": 459,
+        "end": 498,
+        "loc": {
+          "start": {
+            "line": 15,
+            "column": 0
+          },
+          "end": {
+            "line": 15,
+            "column": 39
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 473,
+          "end": 474,
+          "loc": {
+            "start": {
+              "line": 15,
+              "column": 14
+            },
+            "end": {
+              "line": 15,
+              "column": 15
+            }
+          },
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 474,
+          "end": 495,
+          "loc": {
+            "start": {
+              "line": 15,
+              "column": 15
+            },
+            "end": {
+              "line": 15,
+              "column": 36
+            }
+          },
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start": 475,
+              "end": 494,
+              "loc": {
+                "start": {
+                  "line": 15,
+                  "column": 16
+                },
+                "end": {
+                  "line": 15,
+                  "column": 35
+                }
+              },
+              "name": "T",
+              "bound": {
+                "type": "TypeAnnotation",
+                "start": 476,
+                "end": 485,
+                "loc": {
+                  "start": {
+                    "line": 15,
+                    "column": 17
+                  },
+                  "end": {
+                    "line": 15,
+                    "column": 26
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "NullableTypeAnnotation",
+                  "start": 478,
+                  "end": 485,
+                  "loc": {
+                    "start": {
+                      "line": 15,
+                      "column": 19
+                    },
+                    "end": {
+                      "line": 15,
+                      "column": 26
+                    }
+                  },
+                  "typeAnnotation": {
+                    "type": "StringTypeAnnotation",
+                    "start": 479,
+                    "end": 485,
+                    "loc": {
+                      "start": {
+                        "line": 15,
+                        "column": 20
+                      },
+                      "end": {
+                        "line": 15,
+                        "column": 26
+                      }
+                    }
+                  }
+                }
+              },
+              "default": {
+                "type": "StringTypeAnnotation",
+                "start": 488,
+                "end": 494,
+                "loc": {
+                  "start": {
+                    "line": 15,
+                    "column": 29
+                  },
+                  "end": {
+                    "line": 15,
+                    "column": 35
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "extends": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 496,
+          "end": 498,
+          "loc": {
+            "start": {
+              "line": 15,
+              "column": 37
+            },
+            "end": {
+              "line": 15,
+              "column": 39
+            }
+          },
+          "callProperties": [],
+          "properties": [],
+          "indexers": []
+        }
+      },
+      {
+        "type": "DeclareClass",
+        "start": 499,
+        "end": 541,
+        "loc": {
+          "start": {
+            "line": 16,
+            "column": 0
+          },
+          "end": {
+            "line": 16,
+            "column": 42
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 513,
+          "end": 514,
+          "loc": {
+            "start": {
+              "line": 16,
+              "column": 14
+            },
+            "end": {
+              "line": 16,
+              "column": 15
+            }
+          },
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 514,
+          "end": 538,
+          "loc": {
+            "start": {
+              "line": 16,
+              "column": 15
+            },
+            "end": {
+              "line": 16,
+              "column": 39
+            }
+          },
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start": 515,
+              "end": 516,
+              "loc": {
+                "start": {
+                  "line": 16,
+                  "column": 16
+                },
+                "end": {
+                  "line": 16,
+                  "column": 17
+                }
+              },
+              "name": "S"
+            },
+            {
+              "type": "TypeParameter",
+              "start": 518,
+              "end": 537,
+              "loc": {
+                "start": {
+                  "line": 16,
+                  "column": 19
+                },
+                "end": {
+                  "line": 16,
+                  "column": 38
+                }
+              },
+              "name": "T",
+              "bound": {
+                "type": "TypeAnnotation",
+                "start": 519,
+                "end": 528,
+                "loc": {
+                  "start": {
+                    "line": 16,
+                    "column": 20
+                  },
+                  "end": {
+                    "line": 16,
+                    "column": 29
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "NullableTypeAnnotation",
+                  "start": 521,
+                  "end": 528,
+                  "loc": {
+                    "start": {
+                      "line": 16,
+                      "column": 22
+                    },
+                    "end": {
+                      "line": 16,
+                      "column": 29
+                    }
+                  },
+                  "typeAnnotation": {
+                    "type": "StringTypeAnnotation",
+                    "start": 522,
+                    "end": 528,
+                    "loc": {
+                      "start": {
+                        "line": 16,
+                        "column": 23
+                      },
+                      "end": {
+                        "line": 16,
+                        "column": 29
+                      }
+                    }
+                  }
+                }
+              },
+              "default": {
+                "type": "StringTypeAnnotation",
+                "start": 531,
+                "end": 537,
+                "loc": {
+                  "start": {
+                    "line": 16,
+                    "column": 32
+                  },
+                  "end": {
+                    "line": 16,
+                    "column": 38
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "extends": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 539,
+          "end": 541,
+          "loc": {
+            "start": {
+              "line": 16,
+              "column": 40
+            },
+            "end": {
+              "line": 16,
+              "column": 42
+            }
+          },
+          "callProperties": [],
+          "properties": [],
+          "indexers": []
+        }
+      },
+      {
+        "type": "DeclareClass",
+        "start": 542,
+        "end": 593,
+        "loc": {
+          "start": {
+            "line": 17,
+            "column": 0
+          },
+          "end": {
+            "line": 17,
+            "column": 51
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 556,
+          "end": 557,
+          "loc": {
+            "start": {
+              "line": 17,
+              "column": 14
+            },
+            "end": {
+              "line": 17,
+              "column": 15
+            }
+          },
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 557,
+          "end": 590,
+          "loc": {
+            "start": {
+              "line": 17,
+              "column": 15
+            },
+            "end": {
+              "line": 17,
+              "column": 48
+            }
+          },
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start": 558,
+              "end": 568,
+              "loc": {
+                "start": {
+                  "line": 17,
+                  "column": 16
+                },
+                "end": {
+                  "line": 17,
+                  "column": 26
+                }
+              },
+              "name": "S",
+              "default": {
+                "type": "NumberTypeAnnotation",
+                "start": 562,
+                "end": 568,
+                "loc": {
+                  "start": {
+                    "line": 17,
+                    "column": 20
+                  },
+                  "end": {
+                    "line": 17,
+                    "column": 26
+                  }
+                }
+              }
+            },
+            {
+              "type": "TypeParameter",
+              "start": 570,
+              "end": 589,
+              "loc": {
+                "start": {
+                  "line": 17,
+                  "column": 28
+                },
+                "end": {
+                  "line": 17,
+                  "column": 47
+                }
+              },
+              "name": "T",
+              "bound": {
+                "type": "TypeAnnotation",
+                "start": 571,
+                "end": 580,
+                "loc": {
+                  "start": {
+                    "line": 17,
+                    "column": 29
+                  },
+                  "end": {
+                    "line": 17,
+                    "column": 38
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "NullableTypeAnnotation",
+                  "start": 573,
+                  "end": 580,
+                  "loc": {
+                    "start": {
+                      "line": 17,
+                      "column": 31
+                    },
+                    "end": {
+                      "line": 17,
+                      "column": 38
+                    }
+                  },
+                  "typeAnnotation": {
+                    "type": "StringTypeAnnotation",
+                    "start": 574,
+                    "end": 580,
+                    "loc": {
+                      "start": {
+                        "line": 17,
+                        "column": 32
+                      },
+                      "end": {
+                        "line": 17,
+                        "column": 38
+                      }
+                    }
+                  }
+                }
+              },
+              "default": {
+                "type": "StringTypeAnnotation",
+                "start": 583,
+                "end": 589,
+                "loc": {
+                  "start": {
+                    "line": 17,
+                    "column": 41
+                  },
+                  "end": {
+                    "line": 17,
+                    "column": 47
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "extends": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 591,
+          "end": 593,
+          "loc": {
+            "start": {
+              "line": 17,
+              "column": 49
+            },
+            "end": {
+              "line": 17,
+              "column": 51
+            }
+          },
+          "callProperties": [],
+          "properties": [],
+          "indexers": []
+        }
+      },
+      {
+        "type": "InterfaceDeclaration",
+        "start": 594,
+        "end": 620,
+        "loc": {
+          "start": {
+            "line": 18,
+            "column": 0
+          },
+          "end": {
+            "line": 18,
+            "column": 26
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 604,
+          "end": 605,
+          "loc": {
+            "start": {
+              "line": 18,
+              "column": 10
+            },
+            "end": {
+              "line": 18,
+              "column": 11
+            }
+          },
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 605,
+          "end": 617,
+          "loc": {
+            "start": {
+              "line": 18,
+              "column": 11
+            },
+            "end": {
+              "line": 18,
+              "column": 23
+            }
+          },
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start": 606,
+              "end": 616,
+              "loc": {
+                "start": {
+                  "line": 18,
+                  "column": 12
+                },
+                "end": {
+                  "line": 18,
+                  "column": 22
+                }
+              },
+              "name": "T",
+              "default": {
+                "type": "StringTypeAnnotation",
+                "start": 610,
+                "end": 616,
+                "loc": {
+                  "start": {
+                    "line": 18,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 18,
+                    "column": 22
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "extends": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 618,
+          "end": 620,
+          "loc": {
+            "start": {
+              "line": 18,
+              "column": 24
+            },
+            "end": {
+              "line": 18,
+              "column": 26
+            }
+          },
+          "callProperties": [],
+          "properties": [],
+          "indexers": []
+        }
+      },
+      {
+        "type": "InterfaceDeclaration",
+        "start": 621,
+        "end": 656,
+        "loc": {
+          "start": {
+            "line": 19,
+            "column": 0
+          },
+          "end": {
+            "line": 19,
+            "column": 35
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 631,
+          "end": 632,
+          "loc": {
+            "start": {
+              "line": 19,
+              "column": 10
+            },
+            "end": {
+              "line": 19,
+              "column": 11
+            }
+          },
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 632,
+          "end": 653,
+          "loc": {
+            "start": {
+              "line": 19,
+              "column": 11
+            },
+            "end": {
+              "line": 19,
+              "column": 32
+            }
+          },
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start": 633,
+              "end": 652,
+              "loc": {
+                "start": {
+                  "line": 19,
+                  "column": 12
+                },
+                "end": {
+                  "line": 19,
+                  "column": 31
+                }
+              },
+              "name": "T",
+              "bound": {
+                "type": "TypeAnnotation",
+                "start": 634,
+                "end": 643,
+                "loc": {
+                  "start": {
+                    "line": 19,
+                    "column": 13
+                  },
+                  "end": {
+                    "line": 19,
+                    "column": 22
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "NullableTypeAnnotation",
+                  "start": 636,
+                  "end": 643,
+                  "loc": {
+                    "start": {
+                      "line": 19,
+                      "column": 15
+                    },
+                    "end": {
+                      "line": 19,
+                      "column": 22
+                    }
+                  },
+                  "typeAnnotation": {
+                    "type": "StringTypeAnnotation",
+                    "start": 637,
+                    "end": 643,
+                    "loc": {
+                      "start": {
+                        "line": 19,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 19,
+                        "column": 22
+                      }
+                    }
+                  }
+                }
+              },
+              "default": {
+                "type": "StringTypeAnnotation",
+                "start": 646,
+                "end": 652,
+                "loc": {
+                  "start": {
+                    "line": 19,
+                    "column": 25
+                  },
+                  "end": {
+                    "line": 19,
+                    "column": 31
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "extends": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 654,
+          "end": 656,
+          "loc": {
+            "start": {
+              "line": 19,
+              "column": 33
+            },
+            "end": {
+              "line": 19,
+              "column": 35
+            }
+          },
+          "callProperties": [],
+          "properties": [],
+          "indexers": []
+        }
+      },
+      {
+        "type": "InterfaceDeclaration",
+        "start": 657,
+        "end": 695,
+        "loc": {
+          "start": {
+            "line": 20,
+            "column": 0
+          },
+          "end": {
+            "line": 20,
+            "column": 38
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 667,
+          "end": 668,
+          "loc": {
+            "start": {
+              "line": 20,
+              "column": 10
+            },
+            "end": {
+              "line": 20,
+              "column": 11
+            }
+          },
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 668,
+          "end": 692,
+          "loc": {
+            "start": {
+              "line": 20,
+              "column": 11
+            },
+            "end": {
+              "line": 20,
+              "column": 35
+            }
+          },
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start": 669,
+              "end": 670,
+              "loc": {
+                "start": {
+                  "line": 20,
+                  "column": 12
+                },
+                "end": {
+                  "line": 20,
+                  "column": 13
+                }
+              },
+              "name": "S"
+            },
+            {
+              "type": "TypeParameter",
+              "start": 672,
+              "end": 691,
+              "loc": {
+                "start": {
+                  "line": 20,
+                  "column": 15
+                },
+                "end": {
+                  "line": 20,
+                  "column": 34
+                }
+              },
+              "name": "T",
+              "bound": {
+                "type": "TypeAnnotation",
+                "start": 673,
+                "end": 682,
+                "loc": {
+                  "start": {
+                    "line": 20,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 20,
+                    "column": 25
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "NullableTypeAnnotation",
+                  "start": 675,
+                  "end": 682,
+                  "loc": {
+                    "start": {
+                      "line": 20,
+                      "column": 18
+                    },
+                    "end": {
+                      "line": 20,
+                      "column": 25
+                    }
+                  },
+                  "typeAnnotation": {
+                    "type": "StringTypeAnnotation",
+                    "start": 676,
+                    "end": 682,
+                    "loc": {
+                      "start": {
+                        "line": 20,
+                        "column": 19
+                      },
+                      "end": {
+                        "line": 20,
+                        "column": 25
+                      }
+                    }
+                  }
+                }
+              },
+              "default": {
+                "type": "StringTypeAnnotation",
+                "start": 685,
+                "end": 691,
+                "loc": {
+                  "start": {
+                    "line": 20,
+                    "column": 28
+                  },
+                  "end": {
+                    "line": 20,
+                    "column": 34
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "extends": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 693,
+          "end": 695,
+          "loc": {
+            "start": {
+              "line": 20,
+              "column": 36
+            },
+            "end": {
+              "line": 20,
+              "column": 38
+            }
+          },
+          "callProperties": [],
+          "properties": [],
+          "indexers": []
+        }
+      },
+      {
+        "type": "InterfaceDeclaration",
+        "start": 696,
+        "end": 743,
+        "loc": {
+          "start": {
+            "line": 21,
+            "column": 0
+          },
+          "end": {
+            "line": 21,
+            "column": 47
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 706,
+          "end": 707,
+          "loc": {
+            "start": {
+              "line": 21,
+              "column": 10
+            },
+            "end": {
+              "line": 21,
+              "column": 11
+            }
+          },
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 707,
+          "end": 740,
+          "loc": {
+            "start": {
+              "line": 21,
+              "column": 11
+            },
+            "end": {
+              "line": 21,
+              "column": 44
+            }
+          },
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start": 708,
+              "end": 718,
+              "loc": {
+                "start": {
+                  "line": 21,
+                  "column": 12
+                },
+                "end": {
+                  "line": 21,
+                  "column": 22
+                }
+              },
+              "name": "S",
+              "default": {
+                "type": "NumberTypeAnnotation",
+                "start": 712,
+                "end": 718,
+                "loc": {
+                  "start": {
+                    "line": 21,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 21,
+                    "column": 22
+                  }
+                }
+              }
+            },
+            {
+              "type": "TypeParameter",
+              "start": 720,
+              "end": 739,
+              "loc": {
+                "start": {
+                  "line": 21,
+                  "column": 24
+                },
+                "end": {
+                  "line": 21,
+                  "column": 43
+                }
+              },
+              "name": "T",
+              "bound": {
+                "type": "TypeAnnotation",
+                "start": 721,
+                "end": 730,
+                "loc": {
+                  "start": {
+                    "line": 21,
+                    "column": 25
+                  },
+                  "end": {
+                    "line": 21,
+                    "column": 34
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "NullableTypeAnnotation",
+                  "start": 723,
+                  "end": 730,
+                  "loc": {
+                    "start": {
+                      "line": 21,
+                      "column": 27
+                    },
+                    "end": {
+                      "line": 21,
+                      "column": 34
+                    }
+                  },
+                  "typeAnnotation": {
+                    "type": "StringTypeAnnotation",
+                    "start": 724,
+                    "end": 730,
+                    "loc": {
+                      "start": {
+                        "line": 21,
+                        "column": 28
+                      },
+                      "end": {
+                        "line": 21,
+                        "column": 34
+                      }
+                    }
+                  }
+                }
+              },
+              "default": {
+                "type": "StringTypeAnnotation",
+                "start": 733,
+                "end": 739,
+                "loc": {
+                  "start": {
+                    "line": 21,
+                    "column": 37
+                  },
+                  "end": {
+                    "line": 21,
+                    "column": 43
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "extends": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 741,
+          "end": 743,
+          "loc": {
+            "start": {
+              "line": 21,
+              "column": 45
+            },
+            "end": {
+              "line": 21,
+              "column": 47
+            }
+          },
+          "callProperties": [],
+          "properties": [],
+          "indexers": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/flow/type-parameter-declaration/empty/actual.js
+++ b/test/fixtures/flow/type-parameter-declaration/empty/actual.js
@@ -1,0 +1,2 @@
+// Type parameter declaration may not have 0 type parameters
+type Foo<> = number;

--- a/test/fixtures/flow/type-parameter-declaration/empty/options.json
+++ b/test/fixtures/flow/type-parameter-declaration/empty/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token (2:9)"
+}

--- a/test/fixtures/flow/type-parameter-declaration/star/actual.js
+++ b/test/fixtures/flow/type-parameter-declaration/star/actual.js
@@ -1,0 +1,2 @@
+// Star is only for type parameter initialization
+type Foo<*> = number;

--- a/test/fixtures/flow/type-parameter-declaration/star/expected.json
+++ b/test/fixtures/flow/type-parameter-declaration/star/expected.json
@@ -1,0 +1,148 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 71,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 21
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 71,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 21
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "TypeAlias",
+        "start": 50,
+        "end": 71,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 21
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 55,
+          "end": 58,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 5
+            },
+            "end": {
+              "line": 2,
+              "column": 8
+            }
+          },
+          "name": "Foo"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 58,
+          "end": 61,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 8
+            },
+            "end": {
+              "line": 2,
+              "column": 11
+            }
+          },
+          "params": [
+            {
+              "type": "ExistentialTypeParam",
+              "start": 59,
+              "end": 60,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 9
+                },
+                "end": {
+                  "line": 2,
+                  "column": 10
+                }
+              }
+            }
+          ]
+        },
+        "right": {
+          "type": "NumberTypeAnnotation",
+          "start": 64,
+          "end": 70,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 14
+            },
+            "end": {
+              "line": 2,
+              "column": 20
+            }
+          }
+        },
+        "leadingComments": [
+          {
+            "type": "CommentLine",
+            "value": " Star is only for type parameter initialization",
+            "start": 0,
+            "end": 49,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 49
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": " Star is only for type parameter initialization",
+      "start": 0,
+      "end": 49,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 49
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/flow/type-parameter-declaration/star/options.json
+++ b/test/fixtures/flow/type-parameter-declaration/star/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token (2:9)"
+}


### PR DESCRIPTION
The primary goal of this commit is to add the ability to parse type parameter
declarations with defaults, like `type Foo<T = string> = T`. While I was in the
code, I fixed a few small things, like

* Type parameter declarations need 1 or more type parameters.
* The existential type `*` is not a valid type parameter.
* The existential type `*` is a primary type
* The param list for type parameter declarations now consists of
  `TypeParameter` nodes