### PR TITLE
Add conditional assignment plugin

### DIFF
--- a/src/tokenizer/index.js
+++ b/src/tokenizer/index.js
@@ -319,11 +319,22 @@ export default class Tokenizer {
     return this.finishOp(type, width);
   }
 
-  readToken_pipe_amp(code) { // '|&'
+  readToken_pipe() { // '|'
     let next = this.input.charCodeAt(this.state.pos + 1);
-    if (next === code) return this.finishOp(code === 124 ? tt.logicalOR : tt.logicalAND, 2);
+    let third = this.input.charCodeAt(this.state.pos + 2);
+    if (next === 124 && third === 61 && this.hasPlugin("conditionalAssignment")) {
+      return this.finishOp(tt.conditionalAssignment, 3);
+    }
+    if (next === 124) return this.finishOp(tt.logicalOR, 2);
     if (next === 61) return this.finishOp(tt.assign, 2);
-    return this.finishOp(code === 124 ? tt.bitwiseOR : tt.bitwiseAND, 1);
+    return this.finishOp(tt.bitwiseOR, 1);
+  }
+
+  readToken_amp() { // '&'
+    let next = this.input.charCodeAt(this.state.pos + 1);
+    if (next === 38) return this.finishOp(tt.logicalAND, 2);
+    if (next === 61) return this.finishOp(tt.assign, 2);
+    return this.finishOp(tt.bitwiseAND, 1);
   }
 
   readToken_caret() { // '^'
@@ -448,8 +459,11 @@ export default class Tokenizer {
       case 37: case 42: // '%*'
         return this.readToken_mult_modulo(code);
 
-      case 124: case 38: // '|&'
-        return this.readToken_pipe_amp(code);
+      case 124: // '|'
+        return this.readToken_pipe(code);
+
+      case 38: // '&'
+        return this.readToken_amp(code);
 
       case 94: // '^'
         return this.readToken_caret();

--- a/src/tokenizer/types.js
+++ b/src/tokenizer/types.js
@@ -94,7 +94,10 @@ export const types = {
   modulo: binop("%", 10),
   star: binop("*", 10),
   slash: binop("/", 10),
-  exponent: new TokenType("**", {beforeExpr: true, binop: 11, rightAssociative: true})
+  exponent: new TokenType("**", {beforeExpr: true, binop: 11, rightAssociative: true}),
+  conditionalAssignment: new TokenType("||=", {
+    beforeExpr: true, binop: 12, isAssign: true, rightAssociative: true
+  })
 };
 
 // Map keyword names to token types.

--- a/test/fixtures/experimental/conditional-assignment/expression/actual.js
+++ b/test/fixtures/experimental/conditional-assignment/expression/actual.js
@@ -1,0 +1,2 @@
+let foo;
+foo ||= 'foo';

--- a/test/fixtures/experimental/conditional-assignment/expression/expected.js
+++ b/test/fixtures/experimental/conditional-assignment/expression/expected.js
@@ -1,0 +1,366 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 23,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 14
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 23,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 14
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 8,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 8
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 4,
+            "end": 7,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 4
+              },
+              "end": {
+                "line": 1,
+                "column": 7
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 4,
+              "end": 7,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 4
+                },
+                "end": {
+                  "line": 1,
+                  "column": 7
+                }
+              },
+              "name": "foo"
+            },
+            "init": null
+          }
+        ],
+        "kind": "let"
+      },
+      {
+        "type": "ExpressionStatement",
+        "start": 9,
+        "end": 23,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 14
+          }
+        },
+        "expression": {
+          "type": "BinaryExpression",
+          "start": 9,
+          "end": 22,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 0
+            },
+            "end": {
+              "line": 2,
+              "column": 13
+            }
+          },
+          "left": {
+            "type": "Identifier",
+            "start": 9,
+            "end": 12,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 0
+              },
+              "end": {
+                "line": 2,
+                "column": 3
+              }
+            },
+            "name": "foo"
+          },
+          "operator": "||=",
+          "right": {
+            "type": "StringLiteral",
+            "start": 17,
+            "end": 22,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 8
+              },
+              "end": {
+                "line": 2,
+                "column": 13
+              }
+            },
+            "extra": {
+              "rawValue": "foo",
+              "raw": "'foo'"
+            },
+            "value": "foo"
+          }
+        }
+      }
+    ],
+    "directives": []
+  },
+  "comments": [],
+  "tokens": [
+    {
+      "type": {
+        "label": "let",
+        "keyword": "let",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "let",
+      "start": 0,
+      "end": 3,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "foo",
+      "start": 4,
+      "end": 7,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 4
+        },
+        "end": {
+          "line": 1,
+          "column": 7
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 7,
+      "end": 8,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 7
+        },
+        "end": {
+          "line": 1,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "foo",
+      "start": 9,
+      "end": 12,
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 0
+        },
+        "end": {
+          "line": 2,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "||=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": true,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": 12,
+        "updateContext": null
+      },
+      "value": "||=",
+      "start": 13,
+      "end": 16,
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 4
+        },
+        "end": {
+          "line": 2,
+          "column": 7
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "string",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "foo",
+      "start": 17,
+      "end": 22,
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 22,
+      "end": 23,
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 13
+        },
+        "end": {
+          "line": 2,
+          "column": 14
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "eof",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 23,
+      "end": 23,
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 14
+        },
+        "end": {
+          "line": 2,
+          "column": 14
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/experimental/conditional-assignment/options.json
+++ b/test/fixtures/experimental/conditional-assignment/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["conditionalAssignment"]
+}


### PR DESCRIPTION
Adds a conditional assignment operator

```
let foo;
foo ||= 'foo';
foo === 'foo'; // true

let foo = 'foo';
foo ||= 'bar';
foo === 'foo'; // true
```

I'm not really sure how close this PR is to being ready to pull? I probably need to update the documentation. There's an [associated babel pr](https://github.com/babel/babel/pull/3499).