### PR TITLE
Allow use react elements after yield statement

### DIFF
--- a/src/plugins/jsx/index.js
+++ b/src/plugins/jsx/index.js
@@ -16,7 +16,7 @@ tc.j_expr = new TokContext("<tag>...</tag>", true, true);
 
 tt.jsxName = new TokenType("jsxName");
 tt.jsxText = new TokenType("jsxText", { beforeExpr: true });
-tt.jsxTagStart = new TokenType("jsxTagStart");
+tt.jsxTagStart = new TokenType("jsxTagStart", { startsExpr: true });
 tt.jsxTagEnd = new TokenType("jsxTagEnd");
 
 tt.jsxTagStart.updateContext = function() {

--- a/test/fixtures/jsx/basic/yield-tag/actual.js
+++ b/test/fixtures/jsx/basic/yield-tag/actual.js
@@ -1,0 +1,3 @@
+function*it(){
+    yield <a></a>;
+}

--- a/test/fixtures/jsx/basic/yield-tag/expected.json
+++ b/test/fixtures/jsx/basic/yield-tag/expected.json
@@ -1,0 +1,198 @@
+{
+ "type": "File",
+ "start": 0,
+ "end": 35,
+ "loc": {
+  "start": {
+   "line": 1,
+   "column": 0
+  },
+  "end": {
+   "line": 3,
+   "column": 1
+  }
+ },
+ "program": {
+  "type": "Program",
+  "start": 0,
+  "end": 35,
+  "loc": {
+   "start": {
+    "line": 1,
+    "column": 0
+   },
+   "end": {
+    "line": 3,
+    "column": 1
+   }
+  },
+  "sourceType": "script",
+  "body": [
+   {
+    "type": "FunctionDeclaration",
+    "start": 0,
+    "end": 35,
+    "loc": {
+     "start": {
+      "line": 1,
+      "column": 0
+     },
+     "end": {
+      "line": 3,
+      "column": 1
+     }
+    },
+    "id": {
+     "type": "Identifier",
+     "start": 9,
+     "end": 11,
+     "loc": {
+      "start": {
+       "line": 1,
+       "column": 9
+      },
+      "end": {
+       "line": 1,
+       "column": 11
+      }
+     },
+     "name": "it"
+    },
+    "generator": true,
+    "expression": false,
+    "params": [],
+    "body": {
+     "type": "BlockStatement",
+     "start": 13,
+     "end": 35,
+     "loc": {
+      "start": {
+       "line": 1,
+       "column": 13
+      },
+      "end": {
+       "line": 3,
+       "column": 1
+      }
+     },
+     "body": [
+      {
+       "type": "ExpressionStatement",
+       "start": 19,
+       "end": 33,
+       "loc": {
+        "start": {
+         "line": 2,
+         "column": 4
+        },
+        "end": {
+         "line": 2,
+         "column": 18
+        }
+       },
+       "expression": {
+        "type": "YieldExpression",
+        "start": 19,
+        "end": 32,
+        "loc": {
+         "start": {
+          "line": 2,
+          "column": 4
+         },
+         "end": {
+          "line": 2,
+          "column": 17
+         }
+        },
+        "delegate": false,
+        "argument": {
+         "type": "JSXElement",
+         "start": 25,
+         "end": 32,
+         "loc": {
+          "start": {
+           "line": 2,
+           "column": 10
+          },
+          "end": {
+           "line": 2,
+           "column": 17
+          }
+         },
+         "openingElement": {
+          "type": "JSXOpeningElement",
+          "start": 25,
+          "end": 28,
+          "loc": {
+           "start": {
+            "line": 2,
+            "column": 10
+           },
+           "end": {
+            "line": 2,
+            "column": 13
+           }
+          },
+          "attributes": [],
+          "name": {
+           "type": "JSXIdentifier",
+           "start": 26,
+           "end": 27,
+           "loc": {
+            "start": {
+             "line": 2,
+             "column": 11
+            },
+            "end": {
+             "line": 2,
+             "column": 12
+            }
+           },
+           "name": "a"
+          },
+          "selfClosing": false
+         },
+         "closingElement": {
+          "type": "JSXClosingElement",
+          "start": 28,
+          "end": 32,
+          "loc": {
+           "start": {
+            "line": 2,
+            "column": 13
+           },
+           "end": {
+            "line": 2,
+            "column": 17
+           }
+          },
+          "name": {
+           "type": "JSXIdentifier",
+           "start": 30,
+           "end": 31,
+           "loc": {
+            "start": {
+             "line": 2,
+             "column": 15
+            },
+            "end": {
+             "line": 2,
+             "column": 16
+            }
+           },
+           "name": "a"
+          }
+         },
+         "children": []
+        }
+       }
+      }
+     ],
+     "directives": []
+    }
+   }
+  ],
+  "directives": []
+ },
+ "comments": []
+}


### PR DESCRIPTION
Issue #30 is sent 
Write jsx elements directly after yield statement would cause a syntax error (Unexpected token). But according to jsx spec (https://facebook.github.io/jsx/) and ECMAScript spec. JSXElement is a PrimaryExpression which can be used after yield statement.

