### PR TITLE
Add JSX spread children

### DIFF
--- a/src/plugins/jsx/index.js
+++ b/src/plugins/jsx/index.js
@@ -345,6 +345,15 @@ pp.jsxParseElementAt = function(startPos, startLoc) {
           break;
 
         case tt.braceL:
+          if (this.lookahead().type === tt.ellipsis) {
+            let node = this.startNode();
+            this.next();
+            this.next();
+            node.expression = this.parseExpression();
+            this.expect(tt.braceR);
+            children.push(this.finishNode(node, "JSXSpreadChild"));
+            break;
+          }
           children.push(this.jsxParseExpressionContainer());
           break;
 

--- a/test/fixtures/jsx/basic/21/actual.js
+++ b/test/fixtures/jsx/basic/21/actual.js
@@ -1,0 +1,1 @@
+<div {...c}> {...children}{a}{...b}</div>

--- a/test/fixtures/jsx/basic/21/expected.json
+++ b/test/fixtures/jsx/basic/21/expected.json
@@ -1,0 +1,273 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 41,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 41
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 41,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 41
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 41,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 41
+          }
+        },
+        "expression": {
+          "type": "JSXElement",
+          "start": 0,
+          "end": 41,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 41
+            }
+          },
+          "openingElement": {
+            "type": "JSXOpeningElement",
+            "start": 0,
+            "end": 12,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 1,
+                "column": 12
+              }
+            },
+            "attributes": [
+              {
+                "type": "JSXSpreadAttribute",
+                "start": 5,
+                "end": 11,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 11
+                  }
+                },
+                "argument": {
+                  "type": "Identifier",
+                  "start": 9,
+                  "end": 10,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 10
+                    }
+                  },
+                  "name": "c"
+                }
+              }
+            ],
+            "name": {
+              "type": "JSXIdentifier",
+              "start": 1,
+              "end": 4,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 1
+                },
+                "end": {
+                  "line": 1,
+                  "column": 4
+                }
+              },
+              "name": "div"
+            },
+            "selfClosing": false
+          },
+          "closingElement": {
+            "type": "JSXClosingElement",
+            "start": 35,
+            "end": 41,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 35
+              },
+              "end": {
+                "line": 1,
+                "column": 41
+              }
+            },
+            "name": {
+              "type": "JSXIdentifier",
+              "start": 37,
+              "end": 40,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 37
+                },
+                "end": {
+                  "line": 1,
+                  "column": 40
+                }
+              },
+              "name": "div"
+            }
+          },
+          "children": [
+            {
+              "type": "JSXText",
+              "start": 12,
+              "end": 13,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 12
+                },
+                "end": {
+                  "line": 1,
+                  "column": 13
+                }
+              },
+              "extra": null,
+              "value": " "
+            },
+            {
+              "type": "JSXSpreadChild",
+              "start": 13,
+              "end": 26,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 13
+                },
+                "end": {
+                  "line": 1,
+                  "column": 26
+                }
+              },
+              "expression": {
+                "type": "Identifier",
+                "start": 17,
+                "end": 25,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 17
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 25
+                  }
+                },
+                "name": "children"
+              }
+            },
+            {
+              "type": "JSXExpressionContainer",
+              "start": 26,
+              "end": 29,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 26
+                },
+                "end": {
+                  "line": 1,
+                  "column": 29
+                }
+              },
+              "expression": {
+                "type": "Identifier",
+                "start": 27,
+                "end": 28,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 27
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 28
+                  }
+                },
+                "name": "a"
+              }
+            },
+            {
+              "type": "JSXSpreadChild",
+              "start": 29,
+              "end": 35,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 29
+                },
+                "end": {
+                  "line": 1,
+                  "column": 35
+                }
+              },
+              "expression": {
+                "type": "Identifier",
+                "start": 33,
+                "end": 34,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 33
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 34
+                  }
+                },
+                "name": "b"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  },
+  "comments": []
+}


### PR DESCRIPTION
This PR comes from a conversation in https://github.com/facebook/jsx/issues/57 where I recommended adding the ability to spread children. For the full rationale see that issue, here’s an abridged version:

* * *

JSX with React allows us to do this:

```jsx
const TodoList = ({ todos }) => (
  <div>
    {todos.map(todo => <Todo key={todo.id} todo={todo}/>)}
  </div>
)
```

Which translates to this:

```js
const TodoList = ({ todos }) => ({
  type: 'div',
  children: [
    todos.map(todo => …)
  ],
})
```

That doesn’t make sense and it has disadvantages for simpler JSX consumers as well as type systems. Instead JSX should allow us to do this:

```jsx
const TodoList = ({ todos }) => (
  <div>
    {...todos.map(todo => <Todo key={todo.id} todo={todo}/>)}
  </div>
)
```

Which would translate to this:

```js
const TodoList = ({ todos }) => ({
  type: 'div',
  children: [
    ...todos.map(todo => …)
  ],
})
```

This PR aims to extend JSX by allowing the spreading of children like so:

```jsx
<div>{...children}</div>
```

* * *

As another note, it seems like React itself will consider this an anti-pattern. However as JSX is an open standard used by more than just React we should consider the entire ecosystem when considering the merits of this extension. Let’s keep discussion of whether or not the extension should be added to JSX in https://github.com/facebook/jsx/issues/57 and let’s talk about technical implementations here.

In https://github.com/facebook/jsx/issues/57 the language extension got a +1 from @syranide (https://github.com/facebook/jsx/issues/57#issuecomment-226773478) and @sebmarkbage (https://github.com/facebook/jsx/issues/57#issuecomment-226843120).