### PR TITLE
Fix performance regression introduced in 6.8.2

### DIFF
--- a/src/plugins/flow.js
+++ b/src/plugins/flow.js
@@ -732,18 +732,24 @@ export default function (instance) {
 
   instance.extend("parseConditional", function (inner) {
     return function (expr, noIn, startPos, startLoc, refNeedsArrowPos) {
-      const state = this.state.clone();
-      try {
-        return inner.call(this, expr, noIn, startPos, startLoc);
-      } catch (err) {
-        if (refNeedsArrowPos && err instanceof SyntaxError) {
-          this.state = state;
-          refNeedsArrowPos.start = this.state.start;
-          return expr;
-        } else {
-          throw err;
+      // only do the expensive clone if there is a question mark
+      // and if we come from inside parens
+      if (refNeedsArrowPos && this.match(tt.question)) {
+        const state = this.state.clone();
+        try {
+          return inner.call(this, expr, noIn, startPos, startLoc);
+        } catch (err) {
+          if (err instanceof SyntaxError) {
+            this.state = state;
+            refNeedsArrowPos.start = err.pos || this.state.start;
+            return expr;
+          } else {
+            throw err;
+          }
         }
       }
+
+      return inner.call(this, expr, noIn, startPos, startLoc);
     };
   });
 

--- a/test/fixtures/flow/optional-type/2/options.json
+++ b/test/fixtures/flow/optional-type/2/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:12)"
+  "throws": "Unexpected token (1:13)"
 }


### PR DESCRIPTION
This commit e6c11a0 (#19) made a big performance regression.
The reason was that parseConditional was always cloning the current state even if no questionmark (potential conditional or flow-optional
token) was at the current position.
Simply checking if questionmark matches the current token solves the problem.

Fixes #62 

Testcase:

Node: v7.0.0-nightly20160621ecc48a154d
Testfile:
https://gist.githubusercontent.com/milafrerichs/69035da4707ea51886eb/raw/4cb1783c2904f52cbb8a258ee96031f9054d155b/eu.topojson

Before:
<img width="1398" alt="bildschirmfoto 2016-07-02 um 17 09 47" src="https://cloud.githubusercontent.com/assets/231804/16540986/df5626b8-4077-11e6-9abb-edd71c4a83d1.png">

After:
<img width="437" alt="bildschirmfoto 2016-07-02 um 17 08 18" src="https://cloud.githubusercontent.com/assets/231804/16540987/e60c3498-4077-11e6-985d-716a93438a51.png">

