### PR TITLE
Fix accidental fall-through in Flow type parsing.

### DIFF
--- a/src/plugins/flow.js
+++ b/src/plugins/flow.js
@@ -506,6 +506,7 @@ pp.flowParsePrimaryType = function () {
 
         return this.finishNode(node, "FunctionTypeAnnotation");
       }
+      break;
 
     case tt.parenL:
       this.next();

--- a/test/fixtures/flow/type-annotations/106/actual.js
+++ b/test/fixtures/flow/type-annotations/106/actual.js
@@ -1,0 +1,1 @@
+var f: >x:int) => string;

--- a/test/fixtures/flow/type-annotations/106/options.json
+++ b/test/fixtures/flow/type-annotations/106/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token (1:7)"
+}


### PR DESCRIPTION
When parsing a primary type, `>` would erroneously be treated like `(`. For example, `>x:int) => string` was parsed the same as `(x:int) => string`.