### PR TITLE
Small fix for parsing type parameter declarations

### DIFF
--- a/src/plugins/flow.js
+++ b/src/plugins/flow.js
@@ -230,8 +230,11 @@ pp.flowParseTypeParameter = function () {
 };
 
 pp.flowParseTypeParameterDeclaration = function () {
+  const oldInType = this.state.inType;
   let node = this.startNode();
   node.params = [];
+
+  this.state.inType = true;
 
   if (this.isRelational("<") || this.match(tt.jsxTagStart)) {
     this.next();
@@ -246,6 +249,8 @@ pp.flowParseTypeParameterDeclaration = function () {
     }
   } while (!this.isRelational(">"));
   this.expectRelational(">");
+
+  this.state.inType = oldInType;
 
   return this.finishNode(node, "TypeParameterDeclaration");
 };
@@ -1042,12 +1047,9 @@ export default function (instance) {
   // parse function type parameters - function foo<T>() {}
   instance.extend("parseFunctionParams", function (inner) {
     return function (node) {
-      const oldInType = this.state.inType;
-      this.state.inType = true;
       if (this.isRelational("<")) {
         node.typeParameters = this.flowParseTypeParameterDeclaration();
       }
-      this.state.inType = oldInType;
       inner.call(this, node);
     };
   });
@@ -1115,10 +1117,7 @@ export default function (instance) {
         let arrowExpression;
         let typeParameters;
         try {
-          const oldInType = this.state.inType;
-          this.state.inType = true;
           typeParameters = this.flowParseTypeParameterDeclaration();
-          this.state.inType = oldInType;
 
           arrowExpression = inner.apply(this, args);
           arrowExpression.typeParameters = typeParameters;

--- a/test/fixtures/flow/type-parameter-declaration/default/actual.js
+++ b/test/fixtures/flow/type-parameter-declaration/default/actual.js
@@ -19,3 +19,4 @@ interface A<T = string> {}
 interface A<T: ?string = string> {}
 interface A<S, T: ?string = string> {}
 interface A<S = number, T: ?string = string> {}
+type A<T = void> = T

--- a/test/fixtures/flow/type-parameter-declaration/default/expected.json
+++ b/test/fixtures/flow/type-parameter-declaration/default/expected.json
@@ -1,29 +1,29 @@
 {
   "type": "File",
   "start": 0,
-  "end": 743,
+  "end": 764,
   "loc": {
     "start": {
       "line": 1,
       "column": 0
     },
     "end": {
-      "line": 21,
-      "column": 47
+      "line": 22,
+      "column": 20
     }
   },
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 743,
+    "end": 764,
     "loc": {
       "start": {
         "line": 1,
         "column": 0
       },
       "end": {
-        "line": 21,
-        "column": 47
+        "line": 22,
+        "column": 20
       }
     },
     "sourceType": "module",
@@ -3121,6 +3121,117 @@
           "callProperties": [],
           "properties": [],
           "indexers": []
+        }
+      },
+      {
+        "type": "TypeAlias",
+        "start": 744,
+        "end": 764,
+        "loc": {
+          "start": {
+            "line": 22,
+            "column": 0
+          },
+          "end": {
+            "line": 22,
+            "column": 20
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 749,
+          "end": 750,
+          "loc": {
+            "start": {
+              "line": 22,
+              "column": 5
+            },
+            "end": {
+              "line": 22,
+              "column": 6
+            }
+          },
+          "name": "A"
+        },
+        "typeParameters": {
+          "type": "TypeParameterDeclaration",
+          "start": 750,
+          "end": 760,
+          "loc": {
+            "start": {
+              "line": 22,
+              "column": 6
+            },
+            "end": {
+              "line": 22,
+              "column": 16
+            }
+          },
+          "params": [
+            {
+              "type": "TypeParameter",
+              "start": 751,
+              "end": 759,
+              "loc": {
+                "start": {
+                  "line": 22,
+                  "column": 7
+                },
+                "end": {
+                  "line": 22,
+                  "column": 15
+                }
+              },
+              "name": "T",
+              "default": {
+                "type": "VoidTypeAnnotation",
+                "start": 755,
+                "end": 759,
+                "loc": {
+                  "start": {
+                    "line": 22,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 22,
+                    "column": 15
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "right": {
+          "type": "GenericTypeAnnotation",
+          "start": 763,
+          "end": 764,
+          "loc": {
+            "start": {
+              "line": 22,
+              "column": 19
+            },
+            "end": {
+              "line": 22,
+              "column": 20
+            }
+          },
+          "typeParameters": null,
+          "id": {
+            "type": "Identifier",
+            "start": 763,
+            "end": 764,
+            "loc": {
+              "start": {
+                "line": 22,
+                "column": 19
+              },
+              "end": {
+                "line": 22,
+                "column": 20
+              }
+            },
+            "name": "T"
+          }
         }
       }
     ],


### PR DESCRIPTION
When you eat a token, it looks like Babylon automatically lexes the next token. Setting `this.state.inType` changes the behavior of the lexer, so it needs to be set before eating the type. This was causing trouble, since

```
type Foo<T = void> = T;
```

wouldn't parse, since we would eat the `=` token before setting `this.state.inType = true`, which meant `void` was lexed as an expression instead as a type.

However, the whole type parameter declaration should be parsed with `this.state.inType = true` anyway. Sometimes it was, like for functions and arrow functions, but often it was not. This change makes all type parameter declarations be parsed with `this.state.inType = true`.