### PR TITLE
Add support for computed class property names (#120)

### DIFF
--- a/ast/spec.md
+++ b/ast/spec.md
@@ -1021,6 +1021,7 @@ interface ClassProperty <: Node {
   type: "ClassProperty";
   key: Identifier;
   value: Expression;
+  computed: boolean;
 }
 ```
 

--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -672,13 +672,13 @@ pp.parseClassBody = function (node) {
       this.parsePropertyName(method);
     }
 
-    if (!isGenerator && method.key.type === "Identifier" && !method.computed) {
+    if (!isGenerator) {
       if (this.isClassProperty()) {
         classBody.body.push(this.parseClassProperty(method));
         continue;
       }
 
-      if (this.hasPlugin("classConstructorCall") && method.key.name === "call" && this.match(tt.name) && this.state.value === "constructor") {
+      if (method.key.type === "Identifier" && !method.computed && this.hasPlugin("classConstructorCall") && method.key.name === "call" && this.match(tt.name) && this.state.value === "constructor") {
         isConstructorCall = true;
         this.parsePropertyName(method);
       }

--- a/test/fixtures/experimental/class-properties/computed/actual.js
+++ b/test/fixtures/experimental/class-properties/computed/actual.js
@@ -1,0 +1,9 @@
+class Foo {
+  [x]
+  ['y']
+}
+
+class Foo {
+  [p]
+  [m] () {}
+}

--- a/test/fixtures/experimental/class-properties/computed/expected.json
+++ b/test/fixtures/experimental/class-properties/computed/expected.json
@@ -1,0 +1,299 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 60,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 9,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 60,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 9,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 27,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 9,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 9
+            },
+            "identifierName": "Foo"
+          },
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 10,
+          "end": 27,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 10
+            },
+            "end": {
+              "line": 4,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start": 14,
+              "end": 17,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 5
+                }
+              },
+              "computed": true,
+              "key": {
+                "type": "Identifier",
+                "start": 15,
+                "end": 16,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "identifierName": "x"
+                },
+                "name": "x"
+              },
+              "static": false,
+              "value": null
+            },
+            {
+              "type": "ClassProperty",
+              "start": 20,
+              "end": 25,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 7
+                }
+              },
+              "computed": true,
+              "key": {
+                "type": "StringLiteral",
+                "start": 21,
+                "end": 24,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 6
+                  }
+                },
+                "extra": {
+                  "rawValue": "y",
+                  "raw": "'y'"
+                },
+                "value": "y"
+              },
+              "static": false,
+              "value": null
+            }
+          ]
+        }
+      },
+      {
+        "type": "ClassDeclaration",
+        "start": 29,
+        "end": 60,
+        "loc": {
+          "start": {
+            "line": 6,
+            "column": 0
+          },
+          "end": {
+            "line": 9,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 35,
+          "end": 38,
+          "loc": {
+            "start": {
+              "line": 6,
+              "column": 6
+            },
+            "end": {
+              "line": 6,
+              "column": 9
+            },
+            "identifierName": "Foo"
+          },
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 39,
+          "end": 60,
+          "loc": {
+            "start": {
+              "line": 6,
+              "column": 10
+            },
+            "end": {
+              "line": 9,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassProperty",
+              "start": 43,
+              "end": 46,
+              "loc": {
+                "start": {
+                  "line": 7,
+                  "column": 2
+                },
+                "end": {
+                  "line": 7,
+                  "column": 5
+                }
+              },
+              "computed": true,
+              "key": {
+                "type": "Identifier",
+                "start": 44,
+                "end": 45,
+                "loc": {
+                  "start": {
+                    "line": 7,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 7,
+                    "column": 4
+                  },
+                  "identifierName": "p"
+                },
+                "name": "p"
+              },
+              "static": false,
+              "value": null
+            },
+            {
+              "type": "ClassMethod",
+              "start": 49,
+              "end": 58,
+              "loc": {
+                "start": {
+                  "line": 8,
+                  "column": 2
+                },
+                "end": {
+                  "line": 8,
+                  "column": 11
+                }
+              },
+              "computed": true,
+              "key": {
+                "type": "Identifier",
+                "start": 50,
+                "end": 51,
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 4
+                  },
+                  "identifierName": "m"
+                },
+                "name": "m"
+              },
+              "static": false,
+              "kind": "method",
+              "id": null,
+              "generator": false,
+              "expression": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start": 56,
+                "end": 58,
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 11
+                  }
+                },
+                "body": [],
+                "directives": []
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/experimental/class-properties/computed/options.json
+++ b/test/fixtures/experimental/class-properties/computed/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["classProperties"]
+}


### PR DESCRIPTION
First time contributor here - someone please check this for sanity :smile:

I _think_ this implements #120 quite completely. I'm working on a PR for the corresponding changes required in Babel, tracked by babel/babel#4499.