### PR TITLE
Rephrase "assigning/binding to rvalue" errors to include context (#119)

### DIFF
--- a/src/parser/expression.js
+++ b/src/parser/expression.js
@@ -113,10 +113,10 @@ pp.parseMaybeAssign = function (noIn, refShorthandDefaultPos, afterLeftParse, re
   if (this.state.type.isAssign) {
     let node = this.startNodeAt(startPos, startLoc);
     node.operator = this.state.value;
-    node.left = this.match(tt.eq) ? this.toAssignable(left) : left;
+    node.left = this.match(tt.eq) ? this.toAssignable(left, undefined, "assignment expression") : left;
     refShorthandDefaultPos.start = 0; // reset because shorthand default was used correctly
 
-    this.checkLVal(left);
+    this.checkLVal(left, undefined, undefined, "assignment expression");
 
     if (left.extra && left.extra.parenthesized) {
       let errorMsg;
@@ -232,7 +232,7 @@ pp.parseMaybeUnary = function (refShorthandDefaultPos) {
     }
 
     if (update) {
-      this.checkLVal(node.argument);
+      this.checkLVal(node.argument, undefined, undefined, "prefix operation");
     } else if (this.state.strict && node.operator === "delete" && node.argument.type === "Identifier") {
       this.raise(node.start, "Deleting local variable in strict mode");
     }
@@ -248,7 +248,7 @@ pp.parseMaybeUnary = function (refShorthandDefaultPos) {
     node.operator = this.state.value;
     node.prefix = false;
     node.argument = expr;
-    this.checkLVal(expr);
+    this.checkLVal(expr, undefined, undefined, "postfix operation");
     this.next();
     expr = this.finishNode(node, "UpdateExpression");
   }
@@ -855,7 +855,7 @@ pp.parseMethod = function (node, isGenerator, isAsync) {
 
 pp.parseArrowExpression = function (node, params, isAsync) {
   this.initFunction(node, isAsync);
-  node.params = this.toAssignableList(params, true);
+  node.params = this.toAssignableList(params, true, "arrow function parameters");
   this.parseFunctionBody(node, true);
   return this.finishNode(node, "ArrowFunctionExpression");
 };
@@ -911,13 +911,13 @@ pp.parseFunctionBody = function (node, allowExpression) {
     let oldStrict = this.state.strict;
     if (isStrict) this.state.strict = true;
     if (node.id) {
-      this.checkLVal(node.id, true);
+      this.checkLVal(node.id, true, undefined, "function name");
     }
     for (let param of (node.params: Array<Object>)) {
       if (isStrict && param.type !== "Identifier") {
         this.raise(param.start, "Non-simple parameter in strict mode");
       }
-      this.checkLVal(param, true, nameHash);
+      this.checkLVal(param, true, nameHash, "function parameter list");
     }
     this.state.strict = oldStrict;
   }

--- a/src/parser/lval.js
+++ b/src/parser/lval.js
@@ -260,7 +260,8 @@ pp.checkLVal = function (expr, isBinding, checkClashes, contextDescription) {
       break;
 
     default: {
-      const message = (isBinding ? /* istanbul ignore next */ "Binding invalid" : "Invalid") + " left-hand side" +
+      const message = (isBinding ? /* istanbul ignore next */ "Binding invalid" : "Invalid") +
+        " left-hand side" +
         (contextDescription ? " in " + contextDescription : /* istanbul ignore next */ "expression");
       this.raise(expr.start, message);
     }

--- a/src/parser/lval.js
+++ b/src/parser/lval.js
@@ -58,8 +58,11 @@ pp.toAssignable = function (node, isBinding, contextDescription) {
       case "MemberExpression":
         if (!isBinding) break;
 
-      default:
-        this.raise(node.start, "Invalid left-hand side" + (contextDescription ? (" in " + contextDescription) : " expression"));
+      default: {
+        const message = "Invalid left-hand side" +
+          (contextDescription ? " in " + contextDescription : " expression");
+        this.raise(node.start, message);
+      }
     }
   }
   return node;
@@ -256,7 +259,10 @@ pp.checkLVal = function (expr, isBinding, checkClashes, contextDescription) {
       this.checkLVal(expr.argument, isBinding, checkClashes, "rest element");
       break;
 
-    default:
-      this.raise(expr.start, (isBinding ? "Binding invalid" : "Invalid") + " left-hand side" + (contextDescription ? (" in " + contextDescription) : " expression"));
+    default: {
+      const message = (isBinding ? "Binding invalid" : "Invalid") + " left-hand side" +
+        (contextDescription ? " in " + contextDescription : " expression");
+      this.raise(expr.start, message);
+    }
   }
 };

--- a/src/parser/lval.js
+++ b/src/parser/lval.js
@@ -60,7 +60,7 @@ pp.toAssignable = function (node, isBinding, contextDescription) {
 
       default: {
         const message = "Invalid left-hand side" +
-          (contextDescription ? " in " + contextDescription : " expression");
+          (contextDescription ? " in " + contextDescription : /* istanbul ignore next */ "expression");
         this.raise(node.start, message);
       }
     }
@@ -260,8 +260,8 @@ pp.checkLVal = function (expr, isBinding, checkClashes, contextDescription) {
       break;
 
     default: {
-      const message = (isBinding ? "Binding invalid" : "Invalid") + " left-hand side" +
-        (contextDescription ? " in " + contextDescription : " expression");
+      const message = (isBinding ? /* istanbul ignore next */ "Binding invalid" : "Invalid") + " left-hand side" +
+        (contextDescription ? " in " + contextDescription : /* istanbul ignore next */ "expression");
       this.raise(expr.start, message);
     }
   }

--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -259,8 +259,9 @@ pp.parseForStatement = function (node) {
   let refShorthandDefaultPos = {start: 0};
   let init = this.parseExpression(true, refShorthandDefaultPos);
   if (this.match(tt._in) || this.isContextual("of")) {
-    this.toAssignable(init);
-    this.checkLVal(init);
+    const description = this.isContextual("of") ? "for-of statement" : "for-in statement";
+    this.toAssignable(init, undefined, description);
+    this.checkLVal(init, undefined, undefined, description);
     return this.parseForIn(node, init, forAwait);
   } else if (refShorthandDefaultPos.start) {
     this.unexpected(refShorthandDefaultPos.start);
@@ -371,7 +372,7 @@ pp.parseTryStatement = function (node) {
 
     this.expect(tt.parenL);
     clause.param = this.parseBindingAtom();
-    this.checkLVal(clause.param, true, Object.create(null));
+    this.checkLVal(clause.param, true, Object.create(null), "catch clause");
     this.expect(tt.parenR);
 
     clause.body = this.parseBlock();
@@ -564,7 +565,7 @@ pp.parseVar = function (node, isFor, kind) {
 
 pp.parseVarHead = function (decl) {
   decl.id = this.parseBindingAtom();
-  this.checkLVal(decl.id, true);
+  this.checkLVal(decl.id, true, undefined, "variable declaration");
 };
 
 // Parse a function declaration or literal (depending on the
@@ -983,7 +984,7 @@ pp.parseImportSpecifiers = function (node) {
     this.next();
     this.expectContextual("as");
     specifier.local = this.parseIdentifier();
-    this.checkLVal(specifier.local, true);
+    this.checkLVal(specifier.local, true, undefined, "import namespace specifier");
     node.specifiers.push(this.finishNode(specifier, "ImportNamespaceSpecifier"));
     return;
   }
@@ -1000,7 +1001,7 @@ pp.parseImportSpecifiers = function (node) {
     let specifier = this.startNode();
     specifier.imported = this.parseIdentifier(true);
     specifier.local = this.eatContextual("as") ? this.parseIdentifier() : specifier.imported.__clone();
-    this.checkLVal(specifier.local, true);
+    this.checkLVal(specifier.local, true, undefined, "import specifier");
     node.specifiers.push(this.finishNode(specifier, "ImportSpecifier"));
   }
 };
@@ -1008,6 +1009,6 @@ pp.parseImportSpecifiers = function (node) {
 pp.parseImportSpecifierDefault = function (id, startPos, startLoc) {
   let node = this.startNodeAt(startPos, startLoc);
   node.local = id;
-  this.checkLVal(node.local, true);
+  this.checkLVal(node.local, true, undefined, "default import specifier");
   return this.finishNode(node, "ImportDefaultSpecifier");
 };

--- a/src/plugins/flow.js
+++ b/src/plugins/flow.js
@@ -904,25 +904,25 @@ export default function (instance) {
   });
 
   instance.extend("toAssignable", function (inner) {
-    return function (node, isBinding) {
+    return function (node, isBinding, contextDescription) {
       if (node.type === "TypeCastExpression") {
-        return inner.call(this, this.typeCastToParameter(node), isBinding);
+        return inner.call(this, this.typeCastToParameter(node), isBinding, contextDescription);
       } else {
-        return inner.call(this, node, isBinding);
+        return inner.call(this, node, isBinding, contextDescription);
       }
     };
   });
 
   // turn type casts that we found in function parameter head into type annotated params
   instance.extend("toAssignableList", function (inner) {
-    return function (exprList, isBinding) {
+    return function (exprList, isBinding, contextDescription) {
       for (let i = 0; i < exprList.length; i++) {
         let expr = exprList[i];
         if (expr && expr.type === "TypeCastExpression") {
           exprList[i] = this.typeCastToParameter(expr);
         }
       }
-      return inner.call(this, exprList, isBinding);
+      return inner.call(this, exprList, isBinding, contextDescription);
     };
   });
 

--- a/test/fixtures/core/uncategorised/367/options.json
+++ b/test/fixtures/core/uncategorised/367/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:0)"
+  "throws": "Invalid left-hand side in assignment expression (1:0)"
 }

--- a/test/fixtures/core/uncategorised/368/options.json
+++ b/test/fixtures/core/uncategorised/368/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:0)"
+  "throws": "Invalid left-hand side in assignment expression (1:0)"
 }

--- a/test/fixtures/core/uncategorised/369/options.json
+++ b/test/fixtures/core/uncategorised/369/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:1)"
+  "throws": "Invalid left-hand side in assignment expression (1:1)"
 }

--- a/test/fixtures/core/uncategorised/370/options.json
+++ b/test/fixtures/core/uncategorised/370/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:0)"
+  "throws": "Invalid left-hand side in postfix operation (1:0)"
 }

--- a/test/fixtures/core/uncategorised/371/options.json
+++ b/test/fixtures/core/uncategorised/371/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:0)"
+  "throws": "Invalid left-hand side in postfix operation (1:0)"
 }

--- a/test/fixtures/core/uncategorised/372/options.json
+++ b/test/fixtures/core/uncategorised/372/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:2)"
+  "throws": "Invalid left-hand side in prefix operation (1:2)"
 }

--- a/test/fixtures/core/uncategorised/373/options.json
+++ b/test/fixtures/core/uncategorised/373/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:2)"
+  "throws": "Invalid left-hand side in prefix operation (1:2)"
 }

--- a/test/fixtures/core/uncategorised/374/options.json
+++ b/test/fixtures/core/uncategorised/374/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:5)"
+  "throws": "Invalid left-hand side in for-in statement (1:5)"
 }

--- a/test/fixtures/core/uncategorised/383/options.json
+++ b/test/fixtures/core/uncategorised/383/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:0)"
+  "throws": "Invalid left-hand side in assignment expression (1:0)"
 }

--- a/test/fixtures/core/uncategorised/384/options.json
+++ b/test/fixtures/core/uncategorised/384/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:0)"
+  "throws": "Invalid left-hand side in assignment expression (1:0)"
 }

--- a/test/fixtures/core/uncategorised/417/options.json
+++ b/test/fixtures/core/uncategorised/417/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:5)"
+  "throws": "Invalid left-hand side in for-in statement (1:5)"
 }

--- a/test/fixtures/core/uncategorised/418/options.json
+++ b/test/fixtures/core/uncategorised/418/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:5)"
+  "throws": "Invalid left-hand side in for-in statement (1:5)"
 }

--- a/test/fixtures/es2015/uncategorised/220/options.json
+++ b/test/fixtures/es2015/uncategorised/220/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:0)"
+  "throws": "Invalid left-hand side in assignment expression (1:0)"
 }

--- a/test/fixtures/es2015/uncategorised/221/options.json
+++ b/test/fixtures/es2015/uncategorised/221/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:1)"
+  "throws": "Invalid left-hand side in assignment expression (1:1)"
 }

--- a/test/fixtures/es2015/uncategorised/222/options.json
+++ b/test/fixtures/es2015/uncategorised/222/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:7)"
+  "throws": "Invalid left-hand side in object destructuring pattern (1:7)"
 }

--- a/test/fixtures/es2015/uncategorised/251/options.json
+++ b/test/fixtures/es2015/uncategorised/251/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:1)"
+  "throws": "Invalid left-hand side in arrow function parameters (1:1)"
 }

--- a/test/fixtures/es2015/uncategorised/252/options.json
+++ b/test/fixtures/es2015/uncategorised/252/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:1)"
+  "throws": "Invalid left-hand side in arrow function parameters (1:1)"
 }

--- a/test/fixtures/es2015/uncategorised/284/options.json
+++ b/test/fixtures/es2015/uncategorised/284/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:3)"
+  "throws": "Invalid left-hand side in arrow function parameters (1:3)"
 }

--- a/test/fixtures/es2015/uncategorised/288/options.json
+++ b/test/fixtures/es2015/uncategorised/288/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:1)"
+  "throws": "Invalid left-hand side in assignment expression (1:1)"
 }

--- a/test/fixtures/es2015/uncategorised/37/options.json
+++ b/test/fixtures/es2015/uncategorised/37/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:2)"
+  "throws": "Invalid left-hand side in arrow function parameters (1:2)"
 }

--- a/test/fixtures/esprima/es2015-destructuring-assignment-object-pattern/invalid-lhs-01/options.json
+++ b/test/fixtures/esprima/es2015-destructuring-assignment-object-pattern/invalid-lhs-01/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:4)"
+  "throws": "Invalid left-hand side in object destructuring pattern (1:4)"
 }

--- a/test/fixtures/esprima/es2015-destructuring-assignment-object-pattern/invalid-lhs-02/options.json
+++ b/test/fixtures/esprima/es2015-destructuring-assignment-object-pattern/invalid-lhs-02/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:5)"
+  "throws": "Invalid left-hand side in object destructuring pattern (1:5)"
 }

--- a/test/fixtures/esprima/es2015-destructuring-assignment/invalid-group-assignment/options.json
+++ b/test/fixtures/esprima/es2015-destructuring-assignment/invalid-group-assignment/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:1)"
+  "throws": "Invalid left-hand side in assignment expression (1:1)"
 }

--- a/test/fixtures/esprima/es2015-for-of/invalid-lhs-init/options.json
+++ b/test/fixtures/esprima/es2015-for-of/invalid-lhs-init/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:5)"
+  "throws": "Invalid left-hand side in for-of statement (1:5)"
 }

--- a/test/fixtures/esprima/es2015-yield/invalid-yield-generator-arrow-parameter/options.json
+++ b/test/fixtures/esprima/es2015-yield/invalid-yield-generator-arrow-parameter/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:16)"
+  "throws": "Invalid left-hand side in arrow function parameters (1:16)"
 }

--- a/test/fixtures/esprima/es2015-yield/invalid-yield-generator-arrow-parameters/options.json
+++ b/test/fixtures/esprima/es2015-yield/invalid-yield-generator-arrow-parameters/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:25)"
+  "throws": "Invalid left-hand side in arrow function parameters (1:25)"
 }

--- a/test/fixtures/esprima/invalid-syntax/migrated_0045/options.json
+++ b/test/fixtures/esprima/invalid-syntax/migrated_0045/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:0)"
+  "throws": "Invalid left-hand side in assignment expression (1:0)"
 }

--- a/test/fixtures/esprima/invalid-syntax/migrated_0046/options.json
+++ b/test/fixtures/esprima/invalid-syntax/migrated_0046/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:0)"
+  "throws": "Invalid left-hand side in assignment expression (1:0)"
 }

--- a/test/fixtures/esprima/invalid-syntax/migrated_0047/options.json
+++ b/test/fixtures/esprima/invalid-syntax/migrated_0047/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:1)"
+  "throws": "Invalid left-hand side in assignment expression (1:1)"
 }

--- a/test/fixtures/esprima/invalid-syntax/migrated_0052/options.json
+++ b/test/fixtures/esprima/invalid-syntax/migrated_0052/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:0)"
+  "throws": "Invalid left-hand side in postfix operation (1:0)"
 }

--- a/test/fixtures/esprima/invalid-syntax/migrated_0053/options.json
+++ b/test/fixtures/esprima/invalid-syntax/migrated_0053/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:0)"
+  "throws": "Invalid left-hand side in postfix operation (1:0)"
 }

--- a/test/fixtures/esprima/invalid-syntax/migrated_0054/options.json
+++ b/test/fixtures/esprima/invalid-syntax/migrated_0054/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:2)"
+  "throws": "Invalid left-hand side in prefix operation (1:2)"
 }

--- a/test/fixtures/esprima/invalid-syntax/migrated_0055/options.json
+++ b/test/fixtures/esprima/invalid-syntax/migrated_0055/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:2)"
+  "throws": "Invalid left-hand side in prefix operation (1:2)"
 }

--- a/test/fixtures/esprima/invalid-syntax/migrated_0056/options.json
+++ b/test/fixtures/esprima/invalid-syntax/migrated_0056/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:5)"
+  "throws": "Invalid left-hand side in for-in statement (1:5)"
 }

--- a/test/fixtures/esprima/invalid-syntax/migrated_0066/options.json
+++ b/test/fixtures/esprima/invalid-syntax/migrated_0066/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:0)"
+  "throws": "Invalid left-hand side in assignment expression (1:0)"
 }

--- a/test/fixtures/esprima/invalid-syntax/migrated_0067/options.json
+++ b/test/fixtures/esprima/invalid-syntax/migrated_0067/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:0)"
+  "throws": "Invalid left-hand side in assignment expression (1:0)"
 }

--- a/test/fixtures/esprima/invalid-syntax/migrated_0098/options.json
+++ b/test/fixtures/esprima/invalid-syntax/migrated_0098/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:1)"
+  "throws": "Invalid left-hand side in arrow function parameters (1:1)"
 }

--- a/test/fixtures/esprima/invalid-syntax/migrated_0099/options.json
+++ b/test/fixtures/esprima/invalid-syntax/migrated_0099/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:1)"
+  "throws": "Invalid left-hand side in arrow function parameters (1:1)"
 }

--- a/test/fixtures/esprima/invalid-syntax/migrated_0125/options.json
+++ b/test/fixtures/esprima/invalid-syntax/migrated_0125/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:5)"
+  "throws": "Invalid left-hand side in for-in statement (1:5)"
 }

--- a/test/fixtures/esprima/invalid-syntax/migrated_0126/options.json
+++ b/test/fixtures/esprima/invalid-syntax/migrated_0126/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Assigning to rvalue (1:5)"
+  "throws": "Invalid left-hand side in for-in statement (1:5)"
 }


### PR DESCRIPTION
This replaces all "Assigning to rvalue" and "Binding rvalue" errors with more detailed variants based on the example in #119.

The implementation is the most straightforward one I could come up with - I add an optional context argument to `checkLVal`, `toAssignable` and `toAssignableList`, a simple string which is interpolated into the final error message (if any).

In some cases I made decisions that make the messages more informative in my view - e.g. making `ArrayPattern` pass through any parent context, so errors look like "invalid left-hand side in assignment expression" rather than "invalid left-hand side in array destructuring pattern".

### Notes

1. The wording is of course not set in stone and I'll happily implement any suggested changes.
2. It's may be preferred aesthetically to move `contextDescription` leftwards in the methods' parameter lists, to avoid all those added `undefined`s. If there's a specific signature you'd like to see here - please let me know.