### PR TITLE
Fix `static` property falling through in `declare class` Flow AST

### DIFF
--- a/src/plugins/flow.js
+++ b/src/plugins/flow.js
@@ -339,7 +339,7 @@ pp.flowParseObjectType = function (allowStatic, allowExact) {
   let nodeStart = this.startNode();
   let node;
   let propertyKey;
-  let isStatic;
+  let isStatic = false;
 
   nodeStart.callProperties = [];
   nodeStart.properties = [];
@@ -393,6 +393,8 @@ pp.flowParseObjectType = function (allowStatic, allowExact) {
         nodeStart.properties.push(this.finishNode(node, "ObjectTypeProperty"));
       }
     }
+
+    isStatic = false;
   }
 
   this.expect(endDelim);

--- a/test/fixtures/flow/declare-statements/17/actual.js
+++ b/test/fixtures/flow/declare-statements/17/actual.js
@@ -1,0 +1,5 @@
+declare class X {
+	a: number;
+	static b: number;
+	c: number;
+}

--- a/test/fixtures/flow/declare-statements/17/expected.json
+++ b/test/fixtures/flow/declare-statements/17/expected.json
@@ -1,0 +1,236 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 62,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 5,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 62,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 5,
+        "column": 1
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "DeclareClass",
+        "start": 0,
+        "end": 62,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 5,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 14,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 14
+            },
+            "end": {
+              "line": 1,
+              "column": 15
+            },
+            "identifierName": "X"
+          },
+          "name": "X"
+        },
+        "typeParameters": null,
+        "extends": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 16,
+          "end": 62,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 16
+            },
+            "end": {
+              "line": 5,
+              "column": 1
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 19,
+              "end": 29,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 1
+                },
+                "end": {
+                  "line": 2,
+                  "column": 11
+                }
+              },
+              "key": {
+                "type": "Identifier",
+                "start": 19,
+                "end": 20,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 1
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "identifierName": "a"
+                },
+                "name": "a"
+              },
+              "value": {
+                "type": "NumberTypeAnnotation",
+                "start": 22,
+                "end": 28,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 10
+                  }
+                }
+              },
+              "optional": false,
+              "static": false
+            },
+            {
+              "type": "ObjectTypeProperty",
+              "start": 31,
+              "end": 48,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 1
+                },
+                "end": {
+                  "line": 3,
+                  "column": 18
+                }
+              },
+              "key": {
+                "type": "Identifier",
+                "start": 38,
+                "end": 39,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 8
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 9
+                  },
+                  "identifierName": "b"
+                },
+                "name": "b"
+              },
+              "value": {
+                "type": "NumberTypeAnnotation",
+                "start": 41,
+                "end": 47,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 17
+                  }
+                }
+              },
+              "optional": false,
+              "static": true
+            },
+            {
+              "type": "ObjectTypeProperty",
+              "start": 50,
+              "end": 60,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 1
+                },
+                "end": {
+                  "line": 4,
+                  "column": 11
+                }
+              },
+              "key": {
+                "type": "Identifier",
+                "start": 50,
+                "end": 51,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 1
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 2
+                  },
+                  "identifierName": "c"
+                },
+                "name": "c"
+              },
+              "value": {
+                "type": "NumberTypeAnnotation",
+                "start": 53,
+                "end": 59,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 10
+                  }
+                }
+              },
+              "optional": false,
+              "static": false
+            }
+          ],
+          "indexers": [],
+          "exact": false
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
Given the following:

```js
declare class X {
	a: number;
	static b: number;
	c: number;
}
```

`c` would get marked as `static` as it's not being reset between properties.

https://astexplorer.net/#/4Bi9Ce53LA