### PR TITLE
Allow keywords in Flow object property names with type parameters

### DIFF
--- a/src/plugins/flow.js
+++ b/src/plugins/flow.js
@@ -336,6 +336,9 @@ pp.flowParseObjectTypeCallProperty = function (node, isStatic) {
 };
 
 pp.flowParseObjectType = function (allowStatic, allowExact) {
+  const oldInType = this.state.inType;
+  this.state.inType = true;
+
   let nodeStart = this.startNode();
   let node;
   let propertyKey;
@@ -399,7 +402,11 @@ pp.flowParseObjectType = function (allowStatic, allowExact) {
 
   this.expect(endDelim);
 
-  return this.finishNode(nodeStart, "ObjectTypeAnnotation");
+  const out = this.finishNode(nodeStart, "ObjectTypeAnnotation");
+
+  this.state.inType = oldInType;
+
+  return out;
 };
 
 pp.flowObjectTypeSemicolon = function () {

--- a/test/fixtures/flow/type-parameter-declaration/declare-class-method-reserved-word/actual.js
+++ b/test/fixtures/flow/type-parameter-declaration/declare-class-method-reserved-word/actual.js
@@ -1,0 +1,10 @@
+declare class X {
+  foobar<T>(): void;
+  delete<T>(): void;
+  yield<T>(): void;
+  do<T>(): void;
+  static foobar<T>(): void;
+  static delete<T>(): void;
+  static yield<T>(): void;
+  static do<T>(): void;
+};

--- a/test/fixtures/flow/type-parameter-declaration/declare-class-method-reserved-word/expected.json
+++ b/test/fixtures/flow/type-parameter-declaration/declare-class-method-reserved-word/expected.json
@@ -1,0 +1,896 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 206,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 10,
+      "column": 2
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 206,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 10,
+        "column": 2
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "DeclareClass",
+        "start": 0,
+        "end": 205,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 10,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 14,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 14
+            },
+            "end": {
+              "line": 1,
+              "column": 15
+            },
+            "identifierName": "X"
+          },
+          "name": "X"
+        },
+        "typeParameters": null,
+        "extends": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 16,
+          "end": 205,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 16
+            },
+            "end": {
+              "line": 10,
+              "column": 1
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 20,
+              "end": 38,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 20
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 20,
+                "end": 37,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 19
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 26,
+                  "end": 29,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 8
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 11
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 27,
+                      "end": 28,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 10
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 33,
+                  "end": 37,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 15
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 19
+                    }
+                  }
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 20,
+                "end": 26,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 8
+                  },
+                  "identifierName": "foobar"
+                },
+                "name": "foobar"
+              },
+              "optional": false
+            },
+            {
+              "type": "ObjectTypeProperty",
+              "start": 41,
+              "end": 59,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 20
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 41,
+                "end": 58,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 19
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 47,
+                  "end": 50,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 8
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 11
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 48,
+                      "end": 49,
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 10
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 54,
+                  "end": 58,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 15
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 19
+                    }
+                  }
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 41,
+                "end": 47,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 8
+                  },
+                  "identifierName": "delete"
+                },
+                "name": "delete"
+              },
+              "optional": false
+            },
+            {
+              "type": "ObjectTypeProperty",
+              "start": 62,
+              "end": 79,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 2
+                },
+                "end": {
+                  "line": 4,
+                  "column": 19
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 62,
+                "end": 78,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 18
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 67,
+                  "end": 70,
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 10
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 68,
+                      "end": 69,
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 8
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 9
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 74,
+                  "end": 78,
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 14
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 18
+                    }
+                  }
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 62,
+                "end": 67,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 7
+                  },
+                  "identifierName": "yield"
+                },
+                "name": "yield"
+              },
+              "optional": false
+            },
+            {
+              "type": "ObjectTypeProperty",
+              "start": 82,
+              "end": 96,
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 2
+                },
+                "end": {
+                  "line": 5,
+                  "column": 16
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 82,
+                "end": 95,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 15
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 84,
+                  "end": 87,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 4
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 7
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 85,
+                      "end": 86,
+                      "loc": {
+                        "start": {
+                          "line": 5,
+                          "column": 5
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 6
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 91,
+                  "end": 95,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 15
+                    }
+                  }
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 82,
+                "end": 84,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 4
+                  },
+                  "identifierName": "do"
+                },
+                "name": "do"
+              },
+              "optional": false
+            },
+            {
+              "type": "ObjectTypeProperty",
+              "start": 99,
+              "end": 124,
+              "loc": {
+                "start": {
+                  "line": 6,
+                  "column": 2
+                },
+                "end": {
+                  "line": 6,
+                  "column": 27
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 99,
+                "end": 123,
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 26
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 112,
+                  "end": 115,
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 15
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 18
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 113,
+                      "end": 114,
+                      "loc": {
+                        "start": {
+                          "line": 6,
+                          "column": 16
+                        },
+                        "end": {
+                          "line": 6,
+                          "column": 17
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 119,
+                  "end": 123,
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 22
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 26
+                    }
+                  }
+                }
+              },
+              "static": true,
+              "key": {
+                "type": "Identifier",
+                "start": 106,
+                "end": 112,
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 15
+                  },
+                  "identifierName": "foobar"
+                },
+                "name": "foobar"
+              },
+              "optional": false
+            },
+            {
+              "type": "ObjectTypeProperty",
+              "start": 127,
+              "end": 152,
+              "loc": {
+                "start": {
+                  "line": 7,
+                  "column": 2
+                },
+                "end": {
+                  "line": 7,
+                  "column": 27
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 127,
+                "end": 151,
+                "loc": {
+                  "start": {
+                    "line": 7,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 7,
+                    "column": 26
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 140,
+                  "end": 143,
+                  "loc": {
+                    "start": {
+                      "line": 7,
+                      "column": 15
+                    },
+                    "end": {
+                      "line": 7,
+                      "column": 18
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 141,
+                      "end": 142,
+                      "loc": {
+                        "start": {
+                          "line": 7,
+                          "column": 16
+                        },
+                        "end": {
+                          "line": 7,
+                          "column": 17
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 147,
+                  "end": 151,
+                  "loc": {
+                    "start": {
+                      "line": 7,
+                      "column": 22
+                    },
+                    "end": {
+                      "line": 7,
+                      "column": 26
+                    }
+                  }
+                }
+              },
+              "static": true,
+              "key": {
+                "type": "Identifier",
+                "start": 134,
+                "end": 140,
+                "loc": {
+                  "start": {
+                    "line": 7,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 7,
+                    "column": 15
+                  },
+                  "identifierName": "delete"
+                },
+                "name": "delete"
+              },
+              "optional": false
+            },
+            {
+              "type": "ObjectTypeProperty",
+              "start": 155,
+              "end": 179,
+              "loc": {
+                "start": {
+                  "line": 8,
+                  "column": 2
+                },
+                "end": {
+                  "line": 8,
+                  "column": 26
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 155,
+                "end": 178,
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 25
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 167,
+                  "end": 170,
+                  "loc": {
+                    "start": {
+                      "line": 8,
+                      "column": 14
+                    },
+                    "end": {
+                      "line": 8,
+                      "column": 17
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 168,
+                      "end": 169,
+                      "loc": {
+                        "start": {
+                          "line": 8,
+                          "column": 15
+                        },
+                        "end": {
+                          "line": 8,
+                          "column": 16
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 174,
+                  "end": 178,
+                  "loc": {
+                    "start": {
+                      "line": 8,
+                      "column": 21
+                    },
+                    "end": {
+                      "line": 8,
+                      "column": 25
+                    }
+                  }
+                }
+              },
+              "static": true,
+              "key": {
+                "type": "Identifier",
+                "start": 162,
+                "end": 167,
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 14
+                  },
+                  "identifierName": "yield"
+                },
+                "name": "yield"
+              },
+              "optional": false
+            },
+            {
+              "type": "ObjectTypeProperty",
+              "start": 182,
+              "end": 203,
+              "loc": {
+                "start": {
+                  "line": 9,
+                  "column": 2
+                },
+                "end": {
+                  "line": 9,
+                  "column": 23
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 182,
+                "end": 202,
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 22
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 191,
+                  "end": 194,
+                  "loc": {
+                    "start": {
+                      "line": 9,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 9,
+                      "column": 14
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 192,
+                      "end": 193,
+                      "loc": {
+                        "start": {
+                          "line": 9,
+                          "column": 12
+                        },
+                        "end": {
+                          "line": 9,
+                          "column": 13
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 198,
+                  "end": 202,
+                  "loc": {
+                    "start": {
+                      "line": 9,
+                      "column": 18
+                    },
+                    "end": {
+                      "line": 9,
+                      "column": 22
+                    }
+                  }
+                }
+              },
+              "static": true,
+              "key": {
+                "type": "Identifier",
+                "start": 189,
+                "end": 191,
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 11
+                  },
+                  "identifierName": "do"
+                },
+                "name": "do"
+              },
+              "optional": false
+            }
+          ],
+          "indexers": [],
+          "exact": false
+        }
+      },
+      {
+        "type": "EmptyStatement",
+        "start": 205,
+        "end": 206,
+        "loc": {
+          "start": {
+            "line": 10,
+            "column": 1
+          },
+          "end": {
+            "line": 10,
+            "column": 2
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/flow/type-parameter-declaration/declare-class-method-reserved-word/options.json
+++ b/test/fixtures/flow/type-parameter-declaration/declare-class-method-reserved-word/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["flow", "jsx"]
+}

--- a/test/fixtures/flow/type-parameter-declaration/declare-interface-method-reserved-word/actual.js
+++ b/test/fixtures/flow/type-parameter-declaration/declare-interface-method-reserved-word/actual.js
@@ -1,0 +1,6 @@
+declare interface X {
+  foobar<T>(): void;
+  delete<T>(): void;
+  yield<T>(): void;
+  do<T>(): void;
+};

--- a/test/fixtures/flow/type-parameter-declaration/declare-interface-method-reserved-word/expected.json
+++ b/test/fixtures/flow/type-parameter-declaration/declare-interface-method-reserved-word/expected.json
@@ -1,0 +1,500 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 103,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 6,
+      "column": 2
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 103,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 6,
+        "column": 2
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "DeclareInterface",
+        "start": 0,
+        "end": 102,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 18,
+          "end": 19,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 18
+            },
+            "end": {
+              "line": 1,
+              "column": 19
+            },
+            "identifierName": "X"
+          },
+          "name": "X"
+        },
+        "typeParameters": null,
+        "extends": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 20,
+          "end": 102,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 20
+            },
+            "end": {
+              "line": 6,
+              "column": 1
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 24,
+              "end": 42,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 20
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 24,
+                "end": 41,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 19
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 30,
+                  "end": 33,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 8
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 11
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 31,
+                      "end": 32,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 10
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 37,
+                  "end": 41,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 15
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 19
+                    }
+                  }
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 24,
+                "end": 30,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 8
+                  },
+                  "identifierName": "foobar"
+                },
+                "name": "foobar"
+              },
+              "optional": false
+            },
+            {
+              "type": "ObjectTypeProperty",
+              "start": 45,
+              "end": 63,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 20
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 45,
+                "end": 62,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 19
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 51,
+                  "end": 54,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 8
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 11
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 52,
+                      "end": 53,
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 10
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 58,
+                  "end": 62,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 15
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 19
+                    }
+                  }
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 45,
+                "end": 51,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 8
+                  },
+                  "identifierName": "delete"
+                },
+                "name": "delete"
+              },
+              "optional": false
+            },
+            {
+              "type": "ObjectTypeProperty",
+              "start": 66,
+              "end": 83,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 2
+                },
+                "end": {
+                  "line": 4,
+                  "column": 19
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 66,
+                "end": 82,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 18
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 71,
+                  "end": 74,
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 10
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 72,
+                      "end": 73,
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 8
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 9
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 78,
+                  "end": 82,
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 14
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 18
+                    }
+                  }
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 66,
+                "end": 71,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 7
+                  },
+                  "identifierName": "yield"
+                },
+                "name": "yield"
+              },
+              "optional": false
+            },
+            {
+              "type": "ObjectTypeProperty",
+              "start": 86,
+              "end": 100,
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 2
+                },
+                "end": {
+                  "line": 5,
+                  "column": 16
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 86,
+                "end": 99,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 15
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 88,
+                  "end": 91,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 4
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 7
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 89,
+                      "end": 90,
+                      "loc": {
+                        "start": {
+                          "line": 5,
+                          "column": 5
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 6
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 95,
+                  "end": 99,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 15
+                    }
+                  }
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 86,
+                "end": 88,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 4
+                  },
+                  "identifierName": "do"
+                },
+                "name": "do"
+              },
+              "optional": false
+            }
+          ],
+          "indexers": [],
+          "exact": false
+        }
+      },
+      {
+        "type": "EmptyStatement",
+        "start": 102,
+        "end": 103,
+        "loc": {
+          "start": {
+            "line": 6,
+            "column": 1
+          },
+          "end": {
+            "line": 6,
+            "column": 2
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/flow/type-parameter-declaration/declare-interface-method-reserved-word/options.json
+++ b/test/fixtures/flow/type-parameter-declaration/declare-interface-method-reserved-word/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["flow", "jsx"]
+}

--- a/test/fixtures/flow/type-parameter-declaration/interface-reserved-word/actual.js
+++ b/test/fixtures/flow/type-parameter-declaration/interface-reserved-word/actual.js
@@ -1,0 +1,6 @@
+interface X {
+  foobar<T>(): void;
+  delete<T>(): void;
+  yield<T>(): void;
+  do<T>(): void;
+};

--- a/test/fixtures/flow/type-parameter-declaration/interface-reserved-word/expected.json
+++ b/test/fixtures/flow/type-parameter-declaration/interface-reserved-word/expected.json
@@ -1,0 +1,500 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 95,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 6,
+      "column": 2
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 95,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 6,
+        "column": 2
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "InterfaceDeclaration",
+        "start": 0,
+        "end": 94,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 10,
+          "end": 11,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 10
+            },
+            "end": {
+              "line": 1,
+              "column": 11
+            },
+            "identifierName": "X"
+          },
+          "name": "X"
+        },
+        "typeParameters": null,
+        "extends": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 12,
+          "end": 94,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 12
+            },
+            "end": {
+              "line": 6,
+              "column": 1
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 16,
+              "end": 34,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 20
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 16,
+                "end": 33,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 19
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 22,
+                  "end": 25,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 8
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 11
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 23,
+                      "end": 24,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 10
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 29,
+                  "end": 33,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 15
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 19
+                    }
+                  }
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 16,
+                "end": 22,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 8
+                  },
+                  "identifierName": "foobar"
+                },
+                "name": "foobar"
+              },
+              "optional": false
+            },
+            {
+              "type": "ObjectTypeProperty",
+              "start": 37,
+              "end": 55,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 20
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 37,
+                "end": 54,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 19
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 43,
+                  "end": 46,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 8
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 11
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 44,
+                      "end": 45,
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 10
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 50,
+                  "end": 54,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 15
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 19
+                    }
+                  }
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 37,
+                "end": 43,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 8
+                  },
+                  "identifierName": "delete"
+                },
+                "name": "delete"
+              },
+              "optional": false
+            },
+            {
+              "type": "ObjectTypeProperty",
+              "start": 58,
+              "end": 75,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 2
+                },
+                "end": {
+                  "line": 4,
+                  "column": 19
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 58,
+                "end": 74,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 18
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 63,
+                  "end": 66,
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 10
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 64,
+                      "end": 65,
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 8
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 9
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 70,
+                  "end": 74,
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 14
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 18
+                    }
+                  }
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 58,
+                "end": 63,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 7
+                  },
+                  "identifierName": "yield"
+                },
+                "name": "yield"
+              },
+              "optional": false
+            },
+            {
+              "type": "ObjectTypeProperty",
+              "start": 78,
+              "end": 92,
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 2
+                },
+                "end": {
+                  "line": 5,
+                  "column": 16
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 78,
+                "end": 91,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 15
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 80,
+                  "end": 83,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 4
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 7
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 81,
+                      "end": 82,
+                      "loc": {
+                        "start": {
+                          "line": 5,
+                          "column": 5
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 6
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 87,
+                  "end": 91,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 15
+                    }
+                  }
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 78,
+                "end": 80,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 4
+                  },
+                  "identifierName": "do"
+                },
+                "name": "do"
+              },
+              "optional": false
+            }
+          ],
+          "indexers": [],
+          "exact": false
+        }
+      },
+      {
+        "type": "EmptyStatement",
+        "start": 94,
+        "end": 95,
+        "loc": {
+          "start": {
+            "line": 6,
+            "column": 1
+          },
+          "end": {
+            "line": 6,
+            "column": 2
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/flow/type-parameter-declaration/interface-reserved-word/options.json
+++ b/test/fixtures/flow/type-parameter-declaration/interface-reserved-word/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["flow", "jsx"]
+}

--- a/test/fixtures/flow/type-parameter-declaration/type-object-reserved-word/actual.js
+++ b/test/fixtures/flow/type-parameter-declaration/type-object-reserved-word/actual.js
@@ -1,0 +1,6 @@
+type X = {
+  foobar<T>(): void;
+  delete<T>(): void;
+  yield<T>(): void;
+  do<T>(): void;
+};

--- a/test/fixtures/flow/type-parameter-declaration/type-object-reserved-word/expected.json
+++ b/test/fixtures/flow/type-parameter-declaration/type-object-reserved-word/expected.json
@@ -1,0 +1,483 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 92,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 6,
+      "column": 2
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 92,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 6,
+        "column": 2
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "TypeAlias",
+        "start": 0,
+        "end": 92,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 2
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 5,
+          "end": 6,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 5
+            },
+            "end": {
+              "line": 1,
+              "column": 6
+            },
+            "identifierName": "X"
+          },
+          "name": "X"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "ObjectTypeAnnotation",
+          "start": 9,
+          "end": 91,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 9
+            },
+            "end": {
+              "line": 6,
+              "column": 1
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 13,
+              "end": 31,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 2,
+                  "column": 20
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 13,
+                "end": 30,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 19
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 19,
+                  "end": 22,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 8
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 11
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 20,
+                      "end": 21,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 10
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 26,
+                  "end": 30,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 15
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 19
+                    }
+                  }
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 13,
+                "end": 19,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 8
+                  },
+                  "identifierName": "foobar"
+                },
+                "name": "foobar"
+              },
+              "optional": false
+            },
+            {
+              "type": "ObjectTypeProperty",
+              "start": 34,
+              "end": 52,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 20
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 34,
+                "end": 51,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 19
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 40,
+                  "end": 43,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 8
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 11
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 41,
+                      "end": 42,
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 10
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 47,
+                  "end": 51,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 15
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 19
+                    }
+                  }
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 34,
+                "end": 40,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 8
+                  },
+                  "identifierName": "delete"
+                },
+                "name": "delete"
+              },
+              "optional": false
+            },
+            {
+              "type": "ObjectTypeProperty",
+              "start": 55,
+              "end": 72,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 2
+                },
+                "end": {
+                  "line": 4,
+                  "column": 19
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 55,
+                "end": 71,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 18
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 60,
+                  "end": 63,
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 10
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 61,
+                      "end": 62,
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 8
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 9
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 67,
+                  "end": 71,
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 14
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 18
+                    }
+                  }
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 55,
+                "end": 60,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 7
+                  },
+                  "identifierName": "yield"
+                },
+                "name": "yield"
+              },
+              "optional": false
+            },
+            {
+              "type": "ObjectTypeProperty",
+              "start": 75,
+              "end": 89,
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 2
+                },
+                "end": {
+                  "line": 5,
+                  "column": 16
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 75,
+                "end": 88,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 15
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 77,
+                  "end": 80,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 4
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 7
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 78,
+                      "end": 79,
+                      "loc": {
+                        "start": {
+                          "line": 5,
+                          "column": 5
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 6
+                        }
+                      },
+                      "name": "T"
+                    }
+                  ]
+                },
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 84,
+                  "end": 88,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 15
+                    }
+                  }
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 75,
+                "end": 77,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 4
+                  },
+                  "identifierName": "do"
+                },
+                "name": "do"
+              },
+              "optional": false
+            }
+          ],
+          "indexers": [],
+          "exact": false
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/flow/type-parameter-declaration/type-object-reserved-word/options.json
+++ b/test/fixtures/flow/type-parameter-declaration/type-object-reserved-word/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["flow", "jsx"]
+}


### PR DESCRIPTION
For #48. Like the #145 PR, only covers Flow objects instead.

I've also found some of the existing `inType` usages aren't required now, but I'll save removing those for another PR after this.