### PR TITLE
Count Babel tests towards Babylon code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
     - node_js: "node"
       env: BABEL=true
 
-after_success: 'if [ -z "${LINT-}" ] && [ -z "${FLOW-}" ] && [ -z "${BABEL-}" ]; then npm run coverage ; fi'
+after_success: 'if [ -z "${LINT-}" ] && [ -z "${FLOW-}" ]; then npm run coverage ; fi'
 
 notifications:
   slack: babeljs:5Wy4QX13KVkGy9CnU0rmvgeK

--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,5 @@ bootstrap-babel: clean
 test-babel:
 	BABEL_ENV=test npm run build
 	cd ./build/babel; \
-	../../node_modules/.bin/nyc --report-dir ../../coverage node_modules/mocha/bin/_mocha `scripts/_get-test-directories.sh` --opts test/mocha.opts;
+	../../node_modules/.bin/nyc --no-instrument --no-source-map --report-dir ../../coverage node_modules/mocha/bin/_mocha `scripts/_get-test-directories.sh` --opts test/mocha.opts
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ bootstrap-babel: clean
 	find ./build/babel/packages -type d -name 'babylon' -prune -exec rm -rf '{}' \; -exec ln -s '../../../../../' '{}' \;
 
 test-babel:
-	npm run build
+	BABEL_ENV=test npm run build
 	cd ./build/babel; \
-	make test-only
+	../../node_modules/.bin/nyc --report-dir ../../coverage node_modules/mocha/bin/_mocha `scripts/_get-test-directories.sh` --opts test/mocha.opts;
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ bootstrap-babel: clean
 
 test-babel:
 	BABEL_ENV=test npm run build
+	# in case babel ever switches to nyc: filter its config out of package.json
 	cd ./build/babel; \
+	jq "del(.nyc)" package.json > package.nonyc.json; \
+	mv -f package.nonyc.json package.json; \
 	../../node_modules/.bin/nyc --no-instrument --no-source-map --report-dir ../../coverage node_modules/mocha/bin/_mocha `scripts/_get-test-directories.sh` --opts test/mocha.opts
-

--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,5 @@ test-babel:
 	cd ./build/babel; \
 	jq "del(.nyc)" package.json > package.nonyc.json; \
 	mv -f package.nonyc.json package.json; \
-	../../node_modules/.bin/nyc --no-instrument --no-source-map --report-dir ../../coverage node_modules/mocha/bin/_mocha `scripts/_get-test-directories.sh` --opts test/mocha.opts
+	../../node_modules/.bin/nyc --no-instrument --no-source-map --report-dir ../../coverage node_modules/mocha/bin/_mocha `scripts/_get-test-directories.sh` --opts test/mocha.opts; \
+	mv .nyc_output ../../.nyc_output


### PR DESCRIPTION
As we're already running Babel's tests in CI to detect any integration issues early, we can also use them to meaningfully bump up Babylon's test coverage, by doing this with an instrumented build of Babylon and using codecov's automatic report merging feature.

In practice this currently helps us cover things like `do` expressions and the `::` operator which are conspicuously uncovered in the current `master`. Obviously for new features the ideal still is to add covering tests from the get-go.

(Also, file this under "workarounds we can retire if Babylon is ever merged back into the Babel monorepo" 😉)
