### PR TITLE
Error on missing expected.json fixture in CI

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -46,7 +46,7 @@ function runTest(test) {
     throw err;
   }
 
-  if (!test.expect.code && !opts.throws) {
+  if (!test.expect.code && !opts.throws && !process.env.CI) {
     test.expect.loc += "on";
     return save(test, ast);
   }


### PR DESCRIPTION
This blocks (in a CI environment) the default behavior of automatically creating missing `expected.json` files, thereby guarding against silent failure (and a potential false positive) if a test is accidentally committed without its `expected.json`.