### PR TITLE
Correctly eat semicolon at the end of DelcareModuleExports

### DIFF
--- a/src/plugins/flow.js
+++ b/src/plugins/flow.js
@@ -117,6 +117,8 @@ pp.flowParseDeclareModuleExports = function (node) {
   this.expect(tt.dot);
   this.expectContextual("exports");
   node.typeAnnotation = this.flowParseTypeAnnotation();
+  this.semicolon();
+
   return this.finishNode(node, "DeclareModuleExports");
 };
 

--- a/test/fixtures/flow/declare-module/9/actual.js
+++ b/test/fixtures/flow/declare-module/9/actual.js
@@ -1,0 +1,1 @@
+declare module A { declare module.exports: number; }

--- a/test/fixtures/flow/declare-module/9/expected.json
+++ b/test/fixtures/flow/declare-module/9/expected.json
@@ -1,0 +1,128 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 52,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 52
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 52,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 52
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "DeclareModule",
+        "start": 0,
+        "end": 52,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 52
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 15,
+          "end": 16,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 15
+            },
+            "end": {
+              "line": 1,
+              "column": 16
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "body": {
+          "type": "BlockStatement",
+          "start": 17,
+          "end": 52,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 17
+            },
+            "end": {
+              "line": 1,
+              "column": 52
+            }
+          },
+          "body": [
+            {
+              "type": "DeclareModuleExports",
+              "start": 19,
+              "end": 50,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 19
+                },
+                "end": {
+                  "line": 1,
+                  "column": 50
+                }
+              },
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "start": 41,
+                "end": 49,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 41
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 49
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "NumberTypeAnnotation",
+                  "start": 43,
+                  "end": 49,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 43
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 49
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | comma-separated list of tickets fixed by the PR, if any
| License           | MIT

Without this patch this fails

```js
declare module "foo" { declare module.exports: number; }

```

but this works

```js
declare module "foo" { declare module.exports: number }

``` 

In flow both works.

