### PR TITLE
use preset-env in tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,17 +1,29 @@
 {
-  "presets": [
-    ["es2015", {
-      "loose": true,
-      "modules": false
-    }],
-    "stage-0"
-  ],
   "plugins": [
     "transform-flow-strip-types"
   ],
   "env": {
     "test": {
+      "presets": [
+        ["env", {
+          "targets": {
+            "node": "current"
+          },
+          "loose": true,
+          "modules": false
+        }],
+        "stage-0"
+      ],
       "plugins": ["istanbul"]
+    },
+    "production": {
+      "presets": [
+        ["env", {
+          "loose": true,
+          "modules": false
+        }],
+        "stage-0"
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "babel-helper-fixtures": "^6.9.0",
     "babel-plugin-istanbul": "^2.0.1",
     "babel-plugin-transform-flow-strip-types": "^6.14.0",
-    "babel-preset-es2015": "^6.14.0",
+    "babel-preset-env": "^0.0.8",
     "babel-preset-stage-0": "^6.5.0",
     "chalk": "^1.1.3",
     "codecov": "^1.0.1",


### PR DESCRIPTION
Wanted to test out using preset-env on a project..

leaving `"presets": ["stage-0"]` at the top level caused an issue with "missing class properties transform" since I believe the es2015 preset ran before class properties due to env and merging which is unfortunate.

Also means that we're duplicating the config for the different envs