### PR TITLE
Freeze current plugins list for "*" option, and remove from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,6 @@ require("babylon").parse("code", {
 
 ### Plugins
 
-> You can use `"*"` to include everything (may be useful in certain cases)
-
  - `jsx`
  - `flow`
  - `doExpressions`

--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -3,6 +3,19 @@ import { getOptions } from "../options";
 import Tokenizer from "../tokenizer";
 
 export const plugins = {};
+const frozenDeprecatedWildcardPluginList = [
+  "jsx",
+  "doExpressions",
+  "objectRestSpread",
+  "decorators",
+  "classProperties",
+  "exportExtensions",
+  "asyncGenerators",
+  "functionBind",
+  "functionSent",
+  "dynamicImport",
+  "flow"
+];
 
 export default class Parser extends Tokenizer {
   constructor(options: Object, input: string) {
@@ -30,7 +43,11 @@ export default class Parser extends Tokenizer {
   }
 
   hasPlugin(name: string): boolean {
-    return !!(this.plugins["*"] || this.plugins[name]);
+    if (this.plugins["*"] && frozenDeprecatedWildcardPluginList.indexOf(name) > -1) {
+      return true;
+    }
+
+    return !!this.plugins[name];
   }
 
   extend(name: string, f: Function) {
@@ -49,6 +66,7 @@ export default class Parser extends Tokenizer {
   }
 
   loadPlugins(pluginList: Array<string>): { [key: string]: boolean } {
+    // TODO: Deprecate "*" option in next major version of Babylon
     if (pluginList.indexOf("*") >= 0) {
       this.loadAllPlugins();
 


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | yes
| Spec compliancy?  | no
| Tests added/pass? | no
| Fixed tickets     | None
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->

Discussed this with @loganfsmyth and @hzoo a bit. While I love the convenience of having a `*` option, it leads to conflicts when we have conflicting plugins. Right now, this has come up when trying to work on the new decorators proposal (which forbids syntax allowed in the old proposal). But, I can also see this coming up if we ever wanted, say, a TypeScript parser plugin, which would conflict with the Flow plugin.