### PR TITLE
Allow this.state.clone() when parsing decorators

### DIFF
--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -149,7 +149,8 @@ pp.takeDecorators = function (node) {
 
 pp.parseDecorators = function (allowExport) {
   while (this.match(tt.at)) {
-    this.state.decorators.push(this.parseDecorator());
+    let decorator = this.parseDecorator();
+    this.state.decorators.push(decorator);
   }
 
   if (allowExport && this.match(tt._export)) {


### PR DESCRIPTION

<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | none added, existing pass.
| Fixed tickets     | --
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->
Adding the line `this.state = this.state.clone();` in a parser plugin 
(specifically, in my case `parseExprAtom`)
would break decorators. 

This change fixes that.
