### PR TITLE
Don't set inType flag when parsing property names

### DIFF
--- a/src/parser/expression.js
+++ b/src/parser/expression.js
@@ -850,11 +850,14 @@ pp.parsePropertyName = function (prop) {
     prop.computed = true;
     prop.key = this.parseMaybeAssign();
     this.expect(tt.bracketR);
-    return prop.key;
   } else {
     prop.computed = false;
-    return prop.key = (this.match(tt.num) || this.match(tt.string)) ? this.parseExprAtom() : this.parseIdentifier(true);
+    const oldInPropertyName = this.state.inPropertyName;
+    this.state.inPropertyName = true;
+    prop.key = (this.match(tt.num) || this.match(tt.string)) ? this.parseExprAtom() : this.parseIdentifier(true);
+    this.state.inPropertyName = oldInPropertyName;
   }
+  return prop.key;
 };
 
 // Initialize empty function node.

--- a/src/plugins/flow.js
+++ b/src/plugins/flow.js
@@ -954,17 +954,6 @@ export default function (instance) {
     };
   });
 
-  // ensure that inside property names, < isn't interpreted as JSX, but as a type parameter
-  instance.extend("parsePropertyName", function (inner) {
-    return function (prop) {
-      const oldInType = this.state.inType;
-      this.state.inType = true;
-      const out = inner.call(this, prop);
-      this.state.inType = oldInType;
-      return out;
-    };
-  });
-
   // ensure that inside flow types, we bypass the jsx parser plugin
   instance.extend("readToken", function (inner) {
     return function (code) {

--- a/src/plugins/jsx/index.js
+++ b/src/plugins/jsx/index.js
@@ -416,6 +416,10 @@ export default function(instance) {
     return function(code) {
       let context = this.curContext();
 
+      if (this.state.inPropertyName) {
+        return inner.call(this, code);
+      }
+
       if (context === tc.j_expr) {
         return this.jsxReadToken();
       }

--- a/src/tokenizer/state.js
+++ b/src/tokenizer/state.js
@@ -16,6 +16,7 @@ export default class State {
       this.inFunction =
       this.inGenerator =
       this.inAsync =
+      this.inPropertyName =
       this.inType =
       this.noAnonFunctionType =
         false;

--- a/test/fixtures/flow/regression/issue-264/actual.js
+++ b/test/fixtures/flow/regression/issue-264/actual.js
@@ -1,0 +1,3 @@
+const map = {
+  [age <= 17] : 'Too young'
+};

--- a/test/fixtures/flow/regression/issue-264/expected.json
+++ b/test/fixtures/flow/regression/issue-264/expected.json
@@ -1,0 +1,192 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 44,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 2
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 44,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 2
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 44,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 2
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 6,
+            "end": 43,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 6
+              },
+              "end": {
+                "line": 3,
+                "column": 1
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 6,
+              "end": 9,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1,
+                  "column": 9
+                },
+                "identifierName": "map"
+              },
+              "name": "map"
+            },
+            "init": {
+              "type": "ObjectExpression",
+              "start": 12,
+              "end": 43,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 12
+                },
+                "end": {
+                  "line": 3,
+                  "column": 1
+                }
+              },
+              "properties": [
+                {
+                  "type": "ObjectProperty",
+                  "start": 16,
+                  "end": 41,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 27
+                    }
+                  },
+                  "method": false,
+                  "shorthand": false,
+                  "computed": true,
+                  "key": {
+                    "type": "BinaryExpression",
+                    "start": 17,
+                    "end": 26,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 3
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 12
+                      }
+                    },
+                    "left": {
+                      "type": "Identifier",
+                      "start": 17,
+                      "end": 20,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 3
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 6
+                        },
+                        "identifierName": "age"
+                      },
+                      "name": "age"
+                    },
+                    "operator": "<=",
+                    "right": {
+                      "type": "NumericLiteral",
+                      "start": 24,
+                      "end": 26,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 10
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 12
+                        }
+                      },
+                      "extra": {
+                        "rawValue": 17,
+                        "raw": "17"
+                      },
+                      "value": 17
+                    }
+                  },
+                  "value": {
+                    "type": "StringLiteral",
+                    "start": 30,
+                    "end": 41,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 27
+                      }
+                    },
+                    "extra": {
+                      "rawValue": "Too young",
+                      "raw": "'Too young'"
+                    },
+                    "value": "Too young"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "kind": "const"
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | yes
| Fixed tickets     | https://github.com/babel/babylon/issues/264
| License           | MIT

