### PR TITLE
Fix ObjectTypeCallProperty static

### DIFF
--- a/src/plugins/flow.js
+++ b/src/plugins/flow.js
@@ -375,7 +375,7 @@ pp.flowParseObjectType = function (allowStatic, allowExact) {
       if (variance) {
         this.unexpected(variancePos);
       }
-      nodeStart.callProperties.push(this.flowParseObjectTypeCallProperty(node, allowStatic));
+      nodeStart.callProperties.push(this.flowParseObjectTypeCallProperty(node, isStatic));
     } else {
       propertyKey = this.flowParseObjectPropertyKey();
       if (this.isRelational("<") || this.match(tt.parenL)) {

--- a/test/fixtures/flow/declare-statements/18/actual.js
+++ b/test/fixtures/flow/declare-statements/18/actual.js
@@ -1,0 +1,2 @@
+declare class A { static () : number }
+declare class B { () : number }

--- a/test/fixtures/flow/declare-statements/18/expected.json
+++ b/test/fixtures/flow/declare-statements/18/expected.json
@@ -1,0 +1,242 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 70,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 31
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 70,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 31
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "DeclareClass",
+        "start": 0,
+        "end": 38,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 38
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 14,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 14
+            },
+            "end": {
+              "line": 1,
+              "column": 15
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "typeParameters": null,
+        "extends": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 16,
+          "end": 38,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 16
+            },
+            "end": {
+              "line": 1,
+              "column": 38
+            }
+          },
+          "callProperties": [
+            {
+              "type": "ObjectTypeCallProperty",
+              "start": 18,
+              "end": 36,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 18
+                },
+                "end": {
+                  "line": 1,
+                  "column": 36
+                }
+              },
+              "static": true,
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 25,
+                "end": 36,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 25
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 36
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": null,
+                "returnType": {
+                  "type": "NumberTypeAnnotation",
+                  "start": 30,
+                  "end": 36,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 30
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 36
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "properties": [],
+          "indexers": [],
+          "exact": false
+        }
+      },
+      {
+        "type": "DeclareClass",
+        "start": 39,
+        "end": 70,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 31
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 53,
+          "end": 54,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 14
+            },
+            "end": {
+              "line": 2,
+              "column": 15
+            },
+            "identifierName": "B"
+          },
+          "name": "B"
+        },
+        "typeParameters": null,
+        "extends": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 55,
+          "end": 70,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 16
+            },
+            "end": {
+              "line": 2,
+              "column": 31
+            }
+          },
+          "callProperties": [
+            {
+              "type": "ObjectTypeCallProperty",
+              "start": 57,
+              "end": 68,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 18
+                },
+                "end": {
+                  "line": 2,
+                  "column": 29
+                }
+              },
+              "static": true,
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 57,
+                "end": 68,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 18
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 29
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": null,
+                "returnType": {
+                  "type": "NumberTypeAnnotation",
+                  "start": 62,
+                  "end": 68,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 23
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 29
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "properties": [],
+          "indexers": [],
+          "exact": false
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/flow/declare-statements/18/expected.json
+++ b/test/fixtures/flow/declare-statements/18/expected.json
@@ -195,7 +195,7 @@
                   "column": 29
                 }
               },
-              "static": true,
+              "static": false,
               "value": {
                 "type": "FunctionTypeAnnotation",
                 "start": 57,


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | #297
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->

`flowParseObjectTypeCallProperty` was always being passed `allowStatic` instead of `isStatic`.