### PR TITLE
Don't parse class properties without initializers when classProperties plugin is disabled, and Flow is enabled

### DIFF
--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -771,8 +771,13 @@ pp.parseClassBody = function (node) {
 };
 
 pp.parseClassProperty = function (node) {
+  const noPluginMsg = "You can only use Class Properties when the 'classProperties' plugin is enabled.";
+  if (!node.typeAnnotation && !this.hasPlugin("classProperties")) {
+    this.raise(node.start, noPluginMsg);
+  }
+
   if (this.match(tt.eq)) {
-    if (!this.hasPlugin("classProperties")) this.unexpected();
+    if (!this.hasPlugin("classProperties")) this.raise(this.state.start, noPluginMsg);
     this.next();
     node.value = this.parseMaybeAssign();
   } else {

--- a/test/fixtures/experimental/class-properties/with-initializer-and-type-no-plugin/actual.js
+++ b/test/fixtures/experimental/class-properties/with-initializer-and-type-no-plugin/actual.js
@@ -1,0 +1,3 @@
+class Foo {
+  bar: string = 'bizz';
+}

--- a/test/fixtures/experimental/class-properties/with-initializer-and-type-no-plugin/options.json
+++ b/test/fixtures/experimental/class-properties/with-initializer-and-type-no-plugin/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["flow"],
+  "throws": "You can only use Class Properties when the 'classProperties' plugin is enabled. (2:14)"
+}

--- a/test/fixtures/experimental/class-properties/with-initializer-missing-plugin/actual.js
+++ b/test/fixtures/experimental/class-properties/with-initializer-missing-plugin/actual.js
@@ -1,0 +1,3 @@
+class Foo {
+  bar = 'bizz';
+}

--- a/test/fixtures/experimental/class-properties/with-initializer-missing-plugin/options.json
+++ b/test/fixtures/experimental/class-properties/with-initializer-missing-plugin/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "You can only use Class Properties when the 'classProperties' plugin is enabled. (2:2)"
+}

--- a/test/fixtures/experimental/class-properties/without-initializer-missing-plugin/actual.js
+++ b/test/fixtures/experimental/class-properties/without-initializer-missing-plugin/actual.js
@@ -1,0 +1,3 @@
+class Foo {
+  bar;
+}

--- a/test/fixtures/experimental/class-properties/without-initializer-missing-plugin/options.json
+++ b/test/fixtures/experimental/class-properties/without-initializer-missing-plugin/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "You can only use Class Properties when the 'classProperties' plugin is enabled. (2:2)"
+}


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | yes (technically)
| New feature?      | no
| Deprecations?     | yes
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | 
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->

On `master`, we'll currently parse the following, even with `classProperties` disabled

```js
class Foo {
    bar;
}
```

This was happening because we defer the check for the plugin until we're inside the body of `pp.parseClassProperty`, so that `Flow` can parse the following:

```js
class Foo {
    bar: string;
}
```

Once inside of `pp.parseClassProperty`, we were only checking for the plugin if an initializer had been provided.

We unfortunately can't just disallow Flow annotations for class properties when when `classProperties` are disabled, because Flow allows you to do:

```js
class Foo {
   bar: string;

   constructor() {
       this.bar = 'bar';
   }
}
```

I marked this as a breaking change, but it's also technically a bug, so unsure if we want to defer to Babylon 7 or not.