### PR TITLE
keywords are not allowed as local specifier in imports

### DIFF
--- a/src/parser/expression.js
+++ b/src/parser/expression.js
@@ -1018,14 +1018,13 @@ pp.parseExprListItem = function (allowEmpty, refShorthandDefaultPos) {
 
 pp.parseIdentifier = function (liberal) {
   const node = this.startNode();
+  if (!liberal) {
+    this.checkReservedWord(this.state.value, this.state.start, !!this.state.type.keyword, false);
+  }
 
   if (this.match(tt.name)) {
-    if (!liberal) {
-      this.checkReservedWord(this.state.value, this.state.start, false, false);
-    }
-
     node.name = this.state.value;
-  } else if (liberal && this.state.type.keyword) {
+  } else if (this.state.type.keyword) {
     node.name = this.state.type.keyword;
   } else {
     this.unexpected();

--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -1075,7 +1075,12 @@ pp.parseImportSpecifiers = function (node) {
 pp.parseImportSpecifier = function (node) {
   const specifier = this.startNode();
   specifier.imported = this.parseIdentifier(true);
-  specifier.local = this.eatContextual("as") ? this.parseIdentifier() : specifier.imported.__clone();
+  if (this.eatContextual("as")) {
+    specifier.local = this.parseIdentifier();
+  } else {
+    this.checkReservedWord(specifier.imported.name, specifier.start, true, true);
+    specifier.local = specifier.imported.__clone();
+  }
   this.checkLVal(specifier.local, true, undefined, "import specifier");
   node.specifiers.push(this.finishNode(specifier, "ImportSpecifier"));
 };

--- a/src/plugins/flow.js
+++ b/src/plugins/flow.js
@@ -1221,9 +1221,10 @@ export default function (instance) {
         specifierTypeKind = "typeof";
       }
 
+      let isBinding = false;
       if (this.isContextual("as")) {
         const as_ident = this.parseIdentifier(true);
-        if (specifierTypeKind !== null && !this.match(tt.name)) {
+        if (specifierTypeKind !== null && !this.match(tt.name) && !this.state.type.keyword) {
           // `import {type as ,` or `import {type as }`
           specifier.imported = as_ident;
           specifier.importKind = specifierTypeKind;
@@ -1232,23 +1233,20 @@ export default function (instance) {
           // `import {type as foo`
           specifier.imported = firstIdent;
           specifier.importKind = null;
-          specifier.local = this.parseIdentifier(false);
+          specifier.local = this.parseIdentifier();
         }
-      } else if (specifierTypeKind !== null && this.match(tt.name)) {
+      } else if (specifierTypeKind !== null && (this.match(tt.name) || this.state.type.keyword)) {
         // `import {type foo`
         specifier.imported = this.parseIdentifier(true);
         specifier.importKind = specifierTypeKind;
-        specifier.local =
-          this.eatContextual("as")
-          ? this.parseIdentifier(false)
-          : specifier.imported.__clone();
-      } else {
-        if (firstIdent.name === "typeof") {
-          this.unexpected(
-            firstIdentLoc,
-            "Cannot import a variable named `typeof`"
-          );
+        if (this.eatContextual("as")) {
+          specifier.local = this.parseIdentifier();
+        } else {
+          isBinding = true;
+          specifier.local = specifier.imported.__clone();
         }
+      } else {
+        isBinding = true;
         specifier.imported = firstIdent;
         specifier.importKind = null;
         specifier.local = specifier.imported.__clone();
@@ -1260,6 +1258,8 @@ export default function (instance) {
       ) {
         this.raise(firstIdentLoc, "`The `type` and `typeof` keywords on named imports can only be used on regular `import` statements. It cannot be used with `import type` or `import typeof` statements`");
       }
+
+      if (isBinding) this.checkReservedWord(specifier.local.name, specifier.start, true, true);
 
       this.checkLVal(specifier.local, true, undefined, "import specifier");
       node.specifiers.push(this.finishNode(specifier, "ImportSpecifier"));

--- a/test/fixtures/es2015/modules/import-invalid-keyword-flow/actual.js
+++ b/test/fixtures/es2015/modules/import-invalid-keyword-flow/actual.js
@@ -1,0 +1,1 @@
+import { default } from "foo";

--- a/test/fixtures/es2015/modules/import-invalid-keyword-flow/options.json
+++ b/test/fixtures/es2015/modules/import-invalid-keyword-flow/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["flow"],
+  "throws": "default is a reserved word (1:9)"
+}

--- a/test/fixtures/es2015/modules/import-invalid-keyword-typeof-flow/actual.js
+++ b/test/fixtures/es2015/modules/import-invalid-keyword-typeof-flow/actual.js
@@ -1,0 +1,1 @@
+import { typeof } from "foo";

--- a/test/fixtures/es2015/modules/import-invalid-keyword-typeof-flow/options.json
+++ b/test/fixtures/es2015/modules/import-invalid-keyword-typeof-flow/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["flow"],
+  "throws": "typeof is a reserved word (1:9)"
+}

--- a/test/fixtures/es2015/modules/import-invalid-keyword-typeof/actual.js
+++ b/test/fixtures/es2015/modules/import-invalid-keyword-typeof/actual.js
@@ -1,0 +1,1 @@
+import { typeof } from "foo";

--- a/test/fixtures/es2015/modules/import-invalid-keyword-typeof/options.json
+++ b/test/fixtures/es2015/modules/import-invalid-keyword-typeof/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "typeof is a reserved word (1:9)"
+}

--- a/test/fixtures/es2015/modules/import-invalid-keyword/actual.js
+++ b/test/fixtures/es2015/modules/import-invalid-keyword/actual.js
@@ -1,0 +1,1 @@
+import { debugger } from "foo";

--- a/test/fixtures/es2015/modules/import-invalid-keyword/options.json
+++ b/test/fixtures/es2015/modules/import-invalid-keyword/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "debugger is a reserved word (1:9)"
+}

--- a/test/fixtures/esprima/es2015-yield/invalid-yield-generator-declaration/options.json
+++ b/test/fixtures/esprima/es2015-yield/invalid-yield-generator-declaration/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:26)"
+  "throws": "yield is a reserved word (1:26)"
 }

--- a/test/fixtures/esprima/es2015-yield/invalid-yield-generator-function-declaration/options.json
+++ b/test/fixtures/esprima/es2015-yield/invalid-yield-generator-function-declaration/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:25)"
+  "throws": "yield is a reserved word (1:25)"
 }

--- a/test/fixtures/esprima/es2015-yield/invalid-yield-generator-strict-function-expression/options.json
+++ b/test/fixtures/esprima/es2015-yield/invalid-yield-generator-strict-function-expression/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:46)"
+  "throws": "yield is a reserved word (1:46)"
 }

--- a/test/fixtures/esprima/es2015-yield/invalid-yield-strict-identifier/options.json
+++ b/test/fixtures/esprima/es2015-yield/invalid-yield-strict-identifier/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:29)"
+  "throws": "yield is a reserved word (1:29)"
 }

--- a/test/fixtures/esprima/es2015-yield/invalid-yield-strict-rest-parameter/options.json
+++ b/test/fixtures/esprima/es2015-yield/invalid-yield-strict-rest-parameter/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:28)"
+  "throws": "yield is a reserved word (1:28)"
 }

--- a/test/fixtures/flow/type-imports/invalid-import-type-as/actual.js
+++ b/test/fixtures/flow/type-imports/invalid-import-type-as/actual.js
@@ -1,0 +1,1 @@
+import { type as debugger } from "foo";

--- a/test/fixtures/flow/type-imports/invalid-import-type-as/options.json
+++ b/test/fixtures/flow/type-imports/invalid-import-type-as/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "debugger is a reserved word (1:17)"
+}

--- a/test/fixtures/flow/type-imports/invalid-import-type/actual.js
+++ b/test/fixtures/flow/type-imports/invalid-import-type/actual.js
@@ -1,0 +1,1 @@
+import { type debugger } from "foo";

--- a/test/fixtures/flow/type-imports/invalid-import-type/options.json
+++ b/test/fixtures/flow/type-imports/invalid-import-type/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "debugger is a reserved word (1:9)"
+}

--- a/test/fixtures/flow/type-parameter-declaration/reserved-word-class-name-failure/options.json
+++ b/test/fixtures/flow/type-parameter-declaration/reserved-word-class-name-failure/options.json
@@ -1,4 +1,4 @@
 {
-  "throws": "Unexpected token (1:14)",
+  "throws": "delete is a reserved word (1:14)",
   "plugins": ["flow", "jsx"]
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | yes
| Fixed tickets     | 
| License           | MIT

This should not be allowed 

```js
import { default } from "foo";
```

https://www.ecma-international.org/ecma-262/7.0/#prod-BindingIdentifier

The _Identifier_ is an _BindingIdentifier_ and the spec says not _ReservedKeyword_

As flow completely overwrites the parsing I also had to change it there.
Furthermore I fixed the implementation in the flow plugin to consider keywords and not only names and also changed parsing Identifier to always do the _ReservedKeyword_ check, so that the error message gets clearer.
Before: `Unexpected token` (what else would it be?)
After : `<keyword> is a reserved word`