### PR TITLE
Rename NumericLiteralTypeAnnotation to NumberLiteralTypeAnnotation

### DIFF
--- a/src/plugins/flow.js
+++ b/src/plugins/flow.js
@@ -654,7 +654,7 @@ pp.flowParsePrimaryType = function () {
         this.addExtra(node, "rawValue", node.value);
         this.addExtra(node, "raw", this.input.slice(this.state.start, this.state.end));
         this.next();
-        return this.finishNode(node, "NumericLiteralTypeAnnotation");
+        return this.finishNode(node, "NumberLiteralTypeAnnotation");
       }
 
     case tt.num:
@@ -662,7 +662,7 @@ pp.flowParsePrimaryType = function () {
       this.addExtra(node, "rawValue", node.value);
       this.addExtra(node, "raw", this.input.slice(this.state.start, this.state.end));
       this.next();
-      return this.finishNode(node, "NumericLiteralTypeAnnotation");
+      return this.finishNode(node, "NumberLiteralTypeAnnotation");
 
     case tt._null:
       node.value = this.match(tt._null);

--- a/test/fixtures/flow/anonymous-function-no-parens-types/good_05/expected.json
+++ b/test/fixtures/flow/anonymous-function-no-parens-types/good_05/expected.json
@@ -164,7 +164,7 @@
                   ],
                   "rest": null,
                   "returnType": {
-                    "type": "NumericLiteralTypeAnnotation",
+                    "type": "NumberLiteralTypeAnnotation",
                     "start": 24,
                     "end": 27,
                     "loc": {

--- a/test/fixtures/flow/anonymous-function-types/good_10/expected.json
+++ b/test/fixtures/flow/anonymous-function-types/good_10/expected.json
@@ -168,7 +168,7 @@
                   ],
                   "rest": null,
                   "returnType": {
-                    "type": "NumericLiteralTypeAnnotation",
+                    "type": "NumberLiteralTypeAnnotation",
                     "start": 28,
                     "end": 31,
                     "loc": {

--- a/test/fixtures/flow/anonymous-function-types/good_13/expected.json
+++ b/test/fixtures/flow/anonymous-function-types/good_13/expected.json
@@ -158,7 +158,7 @@
                   ],
                   "rest": null,
                   "returnType": {
-                    "type": "NumericLiteralTypeAnnotation",
+                    "type": "NumberLiteralTypeAnnotation",
                     "start": 26,
                     "end": 29,
                     "loc": {

--- a/test/fixtures/flow/anonymous-function-types/good_14/expected.json
+++ b/test/fixtures/flow/anonymous-function-types/good_14/expected.json
@@ -118,7 +118,7 @@
                   },
                   "types": [
                     {
-                      "type": "NumericLiteralTypeAnnotation",
+                      "type": "NumberLiteralTypeAnnotation",
                       "start": 15,
                       "end": 16,
                       "loc": {
@@ -138,7 +138,7 @@
                       }
                     },
                     {
-                      "type": "NumericLiteralTypeAnnotation",
+                      "type": "NumberLiteralTypeAnnotation",
                       "start": 19,
                       "end": 20,
                       "loc": {

--- a/test/fixtures/flow/literal-types/number-binary/expected.json
+++ b/test/fixtures/flow/literal-types/number-binary/expected.json
@@ -87,7 +87,7 @@
                   }
                 },
                 "typeAnnotation": {
-                  "type": "NumericLiteralTypeAnnotation",
+                  "type": "NumberLiteralTypeAnnotation",
                   "start": 7,
                   "end": 16,
                   "loc": {

--- a/test/fixtures/flow/literal-types/number-float/expected.json
+++ b/test/fixtures/flow/literal-types/number-float/expected.json
@@ -87,7 +87,7 @@
                   }
                 },
                 "typeAnnotation": {
-                  "type": "NumericLiteralTypeAnnotation",
+                  "type": "NumberLiteralTypeAnnotation",
                   "start": 7,
                   "end": 12,
                   "loc": {

--- a/test/fixtures/flow/literal-types/number-integer/expected.json
+++ b/test/fixtures/flow/literal-types/number-integer/expected.json
@@ -87,7 +87,7 @@
                   }
                 },
                 "typeAnnotation": {
-                  "type": "NumericLiteralTypeAnnotation",
+                  "type": "NumberLiteralTypeAnnotation",
                   "start": 7,
                   "end": 10,
                   "loc": {

--- a/test/fixtures/flow/literal-types/number-negative-binary/expected.json
+++ b/test/fixtures/flow/literal-types/number-negative-binary/expected.json
@@ -87,7 +87,7 @@
                   }
                 },
                 "typeAnnotation": {
-                  "type": "NumericLiteralTypeAnnotation",
+                  "type": "NumberLiteralTypeAnnotation",
                   "start": 7,
                   "end": 16,
                   "loc": {

--- a/test/fixtures/flow/literal-types/number-negative-float/expected.json
+++ b/test/fixtures/flow/literal-types/number-negative-float/expected.json
@@ -87,7 +87,7 @@
                   }
                 },
                 "typeAnnotation": {
-                  "type": "NumericLiteralTypeAnnotation",
+                  "type": "NumberLiteralTypeAnnotation",
                   "start": 7,
                   "end": 13,
                   "loc": {

--- a/test/fixtures/flow/literal-types/number-negative-octal-2/expected.json
+++ b/test/fixtures/flow/literal-types/number-negative-octal-2/expected.json
@@ -87,7 +87,7 @@
                   }
                 },
                 "typeAnnotation": {
-                  "type": "NumericLiteralTypeAnnotation",
+                  "type": "NumberLiteralTypeAnnotation",
                   "start": 7,
                   "end": 13,
                   "loc": {

--- a/test/fixtures/flow/literal-types/number-negative-octal/expected.json
+++ b/test/fixtures/flow/literal-types/number-negative-octal/expected.json
@@ -87,7 +87,7 @@
                   }
                 },
                 "typeAnnotation": {
-                  "type": "NumericLiteralTypeAnnotation",
+                  "type": "NumberLiteralTypeAnnotation",
                   "start": 7,
                   "end": 12,
                   "loc": {

--- a/test/fixtures/flow/literal-types/number-octal-2/expected.json
+++ b/test/fixtures/flow/literal-types/number-octal-2/expected.json
@@ -87,7 +87,7 @@
                   }
                 },
                 "typeAnnotation": {
-                  "type": "NumericLiteralTypeAnnotation",
+                  "type": "NumberLiteralTypeAnnotation",
                   "start": 7,
                   "end": 12,
                   "loc": {

--- a/test/fixtures/flow/literal-types/number-octal/expected.json
+++ b/test/fixtures/flow/literal-types/number-octal/expected.json
@@ -87,7 +87,7 @@
                   }
                 },
                 "typeAnnotation": {
-                  "type": "NumericLiteralTypeAnnotation",
+                  "type": "NumberLiteralTypeAnnotation",
                   "start": 7,
                   "end": 11,
                   "loc": {

--- a/test/fixtures/flow/type-annotations/129/expected.json
+++ b/test/fixtures/flow/type-annotations/129/expected.json
@@ -103,7 +103,7 @@
                   },
                   "types": [
                     {
-                      "type": "NumericLiteralTypeAnnotation",
+                      "type": "NumberLiteralTypeAnnotation",
                       "start": 10,
                       "end": 11,
                       "loc": {
@@ -123,7 +123,7 @@
                       }
                     },
                     {
-                      "type": "NumericLiteralTypeAnnotation",
+                      "type": "NumberLiteralTypeAnnotation",
                       "start": 15,
                       "end": 16,
                       "loc": {

--- a/test/fixtures/flow/type-annotations/130/expected.json
+++ b/test/fixtures/flow/type-annotations/130/expected.json
@@ -109,7 +109,7 @@
                 },
                 "types": [
                   {
-                    "type": "NumericLiteralTypeAnnotation",
+                    "type": "NumberLiteralTypeAnnotation",
                     "start": 16,
                     "end": 17,
                     "loc": {
@@ -129,7 +129,7 @@
                     }
                   },
                   {
-                    "type": "NumericLiteralTypeAnnotation",
+                    "type": "NumberLiteralTypeAnnotation",
                     "start": 20,
                     "end": 21,
                     "loc": {
@@ -198,7 +198,7 @@
                 },
                 "types": [
                   {
-                    "type": "NumericLiteralTypeAnnotation",
+                    "type": "NumberLiteralTypeAnnotation",
                     "start": 28,
                     "end": 29,
                     "loc": {
@@ -218,7 +218,7 @@
                     }
                   },
                   {
-                    "type": "NumericLiteralTypeAnnotation",
+                    "type": "NumberLiteralTypeAnnotation",
                     "start": 32,
                     "end": 33,
                     "loc": {

--- a/test/fixtures/flow/type-annotations/builtin/expected.json
+++ b/test/fixtures/flow/type-annotations/builtin/expected.json
@@ -637,7 +637,7 @@
         },
         "typeParameters": null,
         "right": {
-          "type": "NumericLiteralTypeAnnotation",
+          "type": "NumberLiteralTypeAnnotation",
           "start": 215,
           "end": 216,
           "loc": {

--- a/test/fixtures/flow/type-annotations/negative-number-literal/expected.json
+++ b/test/fixtures/flow/type-annotations/negative-number-literal/expected.json
@@ -76,7 +76,7 @@
           },
           "types": [
             {
-              "type": "NumericLiteralTypeAnnotation",
+              "type": "NumberLiteralTypeAnnotation",
               "start": 45,
               "end": 47,
               "loc": {
@@ -96,7 +96,7 @@
               }
             },
             {
-              "type": "NumericLiteralTypeAnnotation",
+              "type": "NumberLiteralTypeAnnotation",
               "start": 52,
               "end": 53,
               "loc": {
@@ -116,7 +116,7 @@
               }
             },
             {
-              "type": "NumericLiteralTypeAnnotation",
+              "type": "NumberLiteralTypeAnnotation",
               "start": 58,
               "end": 59,
               "loc": {


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | yes
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | flow
| Tests added/pass? | yes
| Fixed tickets     | #329 
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->

Flow uses `NumberLiteralTypeAnnotation` rather than `NumericLiteralTypeAnnotation`, this brings babylon inline.