### PR TITLE
Add method property to FunctionTypeAnnotation node

### DIFF
--- a/src/plugins/flow.js
+++ b/src/plugins/flow.js
@@ -316,10 +316,11 @@ pp.flowParseObjectTypeIndexer = function (node, isStatic, variance) {
   return this.finishNode(node, "ObjectTypeIndexer");
 };
 
-pp.flowParseObjectTypeMethodish = function (node) {
+pp.flowParseObjectTypeMethodish = function (node, isMethod) {
   node.params = [];
   node.rest = null;
   node.typeParameters = null;
+  node.method = isMethod || false;
 
   if (this.isRelational("<")) {
     node.typeParameters = this.flowParseTypeParameterDeclaration();
@@ -344,7 +345,7 @@ pp.flowParseObjectTypeMethodish = function (node) {
 
 pp.flowParseObjectTypeMethod = function (startPos, startLoc, isStatic, key) {
   const node = this.startNodeAt(startPos, startLoc);
-  node.value = this.flowParseObjectTypeMethodish(this.startNodeAt(startPos, startLoc));
+  node.value = this.flowParseObjectTypeMethodish(this.startNodeAt(startPos, startLoc), true);
   node.static = isStatic;
   node.key = key;
   node.optional = false;

--- a/test/fixtures/flow/type-annotations/object-type-method/actual.js
+++ b/test/fixtures/flow/type-annotations/object-type-method/actual.js
@@ -2,3 +2,11 @@ type T = { a: () => void };
 type T = { a: <T>() => void };
 type T = { a(): void };
 type T = { a<T>(): void };
+
+type T = { (): number };
+type T = { <T>(x: T): number; }
+
+declare class T { foo(): number; }
+declare class T { static foo(): number; }
+declare class T { (): number }
+declare class T { static (): number }

--- a/test/fixtures/flow/type-annotations/object-type-method/actual.js
+++ b/test/fixtures/flow/type-annotations/object-type-method/actual.js
@@ -1,0 +1,4 @@
+type T = { a: () => void };
+type T = { a: <T>() => void };
+type T = { a(): void };
+type T = { a<T>(): void };

--- a/test/fixtures/flow/type-annotations/object-type-method/expected.json
+++ b/test/fixtures/flow/type-annotations/object-type-method/expected.json
@@ -1,29 +1,29 @@
 {
   "type": "File",
   "start": 0,
-  "end": 109,
+  "end": 314,
   "loc": {
     "start": {
       "line": 1,
       "column": 0
     },
     "end": {
-      "line": 4,
-      "column": 26
+      "line": 12,
+      "column": 37
     }
   },
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 109,
+    "end": 314,
     "loc": {
       "start": {
         "line": 1,
         "column": 0
       },
       "end": {
-        "line": 4,
-        "column": 26
+        "line": 12,
+        "column": 37
       }
     },
     "sourceType": "module",
@@ -574,6 +574,768 @@
               "optional": false
             }
           ],
+          "indexers": [],
+          "exact": false
+        }
+      },
+      {
+        "type": "TypeAlias",
+        "start": 111,
+        "end": 135,
+        "loc": {
+          "start": {
+            "line": 6,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 24
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 116,
+          "end": 117,
+          "loc": {
+            "start": {
+              "line": 6,
+              "column": 5
+            },
+            "end": {
+              "line": 6,
+              "column": 6
+            },
+            "identifierName": "T"
+          },
+          "name": "T"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "ObjectTypeAnnotation",
+          "start": 120,
+          "end": 134,
+          "loc": {
+            "start": {
+              "line": 6,
+              "column": 9
+            },
+            "end": {
+              "line": 6,
+              "column": 23
+            }
+          },
+          "callProperties": [
+            {
+              "type": "ObjectTypeCallProperty",
+              "start": 122,
+              "end": 132,
+              "loc": {
+                "start": {
+                  "line": 6,
+                  "column": 11
+                },
+                "end": {
+                  "line": 6,
+                  "column": 21
+                }
+              },
+              "static": false,
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 122,
+                "end": 132,
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 21
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": null,
+                "method": false,
+                "returnType": {
+                  "type": "NumberTypeAnnotation",
+                  "start": 126,
+                  "end": 132,
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 15
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 21
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "properties": [],
+          "indexers": [],
+          "exact": false
+        }
+      },
+      {
+        "type": "TypeAlias",
+        "start": 136,
+        "end": 167,
+        "loc": {
+          "start": {
+            "line": 7,
+            "column": 0
+          },
+          "end": {
+            "line": 7,
+            "column": 31
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 141,
+          "end": 142,
+          "loc": {
+            "start": {
+              "line": 7,
+              "column": 5
+            },
+            "end": {
+              "line": 7,
+              "column": 6
+            },
+            "identifierName": "T"
+          },
+          "name": "T"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "ObjectTypeAnnotation",
+          "start": 145,
+          "end": 167,
+          "loc": {
+            "start": {
+              "line": 7,
+              "column": 9
+            },
+            "end": {
+              "line": 7,
+              "column": 31
+            }
+          },
+          "callProperties": [
+            {
+              "type": "ObjectTypeCallProperty",
+              "start": 147,
+              "end": 165,
+              "loc": {
+                "start": {
+                  "line": 7,
+                  "column": 11
+                },
+                "end": {
+                  "line": 7,
+                  "column": 29
+                }
+              },
+              "static": false,
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 147,
+                "end": 164,
+                "loc": {
+                  "start": {
+                    "line": 7,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 7,
+                    "column": 28
+                  }
+                },
+                "params": [
+                  {
+                    "type": "FunctionTypeParam",
+                    "start": 151,
+                    "end": 155,
+                    "loc": {
+                      "start": {
+                        "line": 7,
+                        "column": 15
+                      },
+                      "end": {
+                        "line": 7,
+                        "column": 19
+                      }
+                    },
+                    "name": {
+                      "type": "Identifier",
+                      "start": 151,
+                      "end": 152,
+                      "loc": {
+                        "start": {
+                          "line": 7,
+                          "column": 15
+                        },
+                        "end": {
+                          "line": 7,
+                          "column": 16
+                        },
+                        "identifierName": "x"
+                      },
+                      "name": "x"
+                    },
+                    "optional": false,
+                    "typeAnnotation": {
+                      "type": "GenericTypeAnnotation",
+                      "start": 154,
+                      "end": 155,
+                      "loc": {
+                        "start": {
+                          "line": 7,
+                          "column": 18
+                        },
+                        "end": {
+                          "line": 7,
+                          "column": 19
+                        }
+                      },
+                      "typeParameters": null,
+                      "id": {
+                        "type": "Identifier",
+                        "start": 154,
+                        "end": 155,
+                        "loc": {
+                          "start": {
+                            "line": 7,
+                            "column": 18
+                          },
+                          "end": {
+                            "line": 7,
+                            "column": 19
+                          },
+                          "identifierName": "T"
+                        },
+                        "name": "T"
+                      }
+                    }
+                  }
+                ],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 147,
+                  "end": 150,
+                  "loc": {
+                    "start": {
+                      "line": 7,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 7,
+                      "column": 14
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 148,
+                      "end": 149,
+                      "loc": {
+                        "start": {
+                          "line": 7,
+                          "column": 12
+                        },
+                        "end": {
+                          "line": 7,
+                          "column": 13
+                        }
+                      },
+                      "name": "T",
+                      "variance": null
+                    }
+                  ]
+                },
+                "method": false,
+                "returnType": {
+                  "type": "NumberTypeAnnotation",
+                  "start": 158,
+                  "end": 164,
+                  "loc": {
+                    "start": {
+                      "line": 7,
+                      "column": 22
+                    },
+                    "end": {
+                      "line": 7,
+                      "column": 28
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "properties": [],
+          "indexers": [],
+          "exact": false
+        }
+      },
+      {
+        "type": "DeclareClass",
+        "start": 169,
+        "end": 203,
+        "loc": {
+          "start": {
+            "line": 9,
+            "column": 0
+          },
+          "end": {
+            "line": 9,
+            "column": 34
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 183,
+          "end": 184,
+          "loc": {
+            "start": {
+              "line": 9,
+              "column": 14
+            },
+            "end": {
+              "line": 9,
+              "column": 15
+            },
+            "identifierName": "T"
+          },
+          "name": "T"
+        },
+        "typeParameters": null,
+        "extends": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 185,
+          "end": 203,
+          "loc": {
+            "start": {
+              "line": 9,
+              "column": 16
+            },
+            "end": {
+              "line": 9,
+              "column": 34
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 187,
+              "end": 201,
+              "loc": {
+                "start": {
+                  "line": 9,
+                  "column": 18
+                },
+                "end": {
+                  "line": 9,
+                  "column": 32
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 187,
+                "end": 200,
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 18
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 31
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": null,
+                "method": true,
+                "returnType": {
+                  "type": "NumberTypeAnnotation",
+                  "start": 194,
+                  "end": 200,
+                  "loc": {
+                    "start": {
+                      "line": 9,
+                      "column": 25
+                    },
+                    "end": {
+                      "line": 9,
+                      "column": 31
+                    }
+                  }
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 187,
+                "end": 190,
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 18
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 21
+                  },
+                  "identifierName": "foo"
+                },
+                "name": "foo"
+              },
+              "optional": false
+            }
+          ],
+          "indexers": [],
+          "exact": false
+        }
+      },
+      {
+        "type": "DeclareClass",
+        "start": 204,
+        "end": 245,
+        "loc": {
+          "start": {
+            "line": 10,
+            "column": 0
+          },
+          "end": {
+            "line": 10,
+            "column": 41
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 218,
+          "end": 219,
+          "loc": {
+            "start": {
+              "line": 10,
+              "column": 14
+            },
+            "end": {
+              "line": 10,
+              "column": 15
+            },
+            "identifierName": "T"
+          },
+          "name": "T"
+        },
+        "typeParameters": null,
+        "extends": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 220,
+          "end": 245,
+          "loc": {
+            "start": {
+              "line": 10,
+              "column": 16
+            },
+            "end": {
+              "line": 10,
+              "column": 41
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 222,
+              "end": 243,
+              "loc": {
+                "start": {
+                  "line": 10,
+                  "column": 18
+                },
+                "end": {
+                  "line": 10,
+                  "column": 39
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 222,
+                "end": 242,
+                "loc": {
+                  "start": {
+                    "line": 10,
+                    "column": 18
+                  },
+                  "end": {
+                    "line": 10,
+                    "column": 38
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": null,
+                "method": true,
+                "returnType": {
+                  "type": "NumberTypeAnnotation",
+                  "start": 236,
+                  "end": 242,
+                  "loc": {
+                    "start": {
+                      "line": 10,
+                      "column": 32
+                    },
+                    "end": {
+                      "line": 10,
+                      "column": 38
+                    }
+                  }
+                }
+              },
+              "static": true,
+              "key": {
+                "type": "Identifier",
+                "start": 229,
+                "end": 232,
+                "loc": {
+                  "start": {
+                    "line": 10,
+                    "column": 25
+                  },
+                  "end": {
+                    "line": 10,
+                    "column": 28
+                  },
+                  "identifierName": "foo"
+                },
+                "name": "foo"
+              },
+              "optional": false
+            }
+          ],
+          "indexers": [],
+          "exact": false
+        }
+      },
+      {
+        "type": "DeclareClass",
+        "start": 246,
+        "end": 276,
+        "loc": {
+          "start": {
+            "line": 11,
+            "column": 0
+          },
+          "end": {
+            "line": 11,
+            "column": 30
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 260,
+          "end": 261,
+          "loc": {
+            "start": {
+              "line": 11,
+              "column": 14
+            },
+            "end": {
+              "line": 11,
+              "column": 15
+            },
+            "identifierName": "T"
+          },
+          "name": "T"
+        },
+        "typeParameters": null,
+        "extends": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 262,
+          "end": 276,
+          "loc": {
+            "start": {
+              "line": 11,
+              "column": 16
+            },
+            "end": {
+              "line": 11,
+              "column": 30
+            }
+          },
+          "callProperties": [
+            {
+              "type": "ObjectTypeCallProperty",
+              "start": 264,
+              "end": 274,
+              "loc": {
+                "start": {
+                  "line": 11,
+                  "column": 18
+                },
+                "end": {
+                  "line": 11,
+                  "column": 28
+                }
+              },
+              "static": false,
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 264,
+                "end": 274,
+                "loc": {
+                  "start": {
+                    "line": 11,
+                    "column": 18
+                  },
+                  "end": {
+                    "line": 11,
+                    "column": 28
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": null,
+                "method": false,
+                "returnType": {
+                  "type": "NumberTypeAnnotation",
+                  "start": 268,
+                  "end": 274,
+                  "loc": {
+                    "start": {
+                      "line": 11,
+                      "column": 22
+                    },
+                    "end": {
+                      "line": 11,
+                      "column": 28
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "properties": [],
+          "indexers": [],
+          "exact": false
+        }
+      },
+      {
+        "type": "DeclareClass",
+        "start": 277,
+        "end": 314,
+        "loc": {
+          "start": {
+            "line": 12,
+            "column": 0
+          },
+          "end": {
+            "line": 12,
+            "column": 37
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 291,
+          "end": 292,
+          "loc": {
+            "start": {
+              "line": 12,
+              "column": 14
+            },
+            "end": {
+              "line": 12,
+              "column": 15
+            },
+            "identifierName": "T"
+          },
+          "name": "T"
+        },
+        "typeParameters": null,
+        "extends": [],
+        "mixins": [],
+        "body": {
+          "type": "ObjectTypeAnnotation",
+          "start": 293,
+          "end": 314,
+          "loc": {
+            "start": {
+              "line": 12,
+              "column": 16
+            },
+            "end": {
+              "line": 12,
+              "column": 37
+            }
+          },
+          "callProperties": [
+            {
+              "type": "ObjectTypeCallProperty",
+              "start": 295,
+              "end": 312,
+              "loc": {
+                "start": {
+                  "line": 12,
+                  "column": 18
+                },
+                "end": {
+                  "line": 12,
+                  "column": 35
+                }
+              },
+              "static": true,
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 302,
+                "end": 312,
+                "loc": {
+                  "start": {
+                    "line": 12,
+                    "column": 25
+                  },
+                  "end": {
+                    "line": 12,
+                    "column": 35
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": null,
+                "method": false,
+                "returnType": {
+                  "type": "NumberTypeAnnotation",
+                  "start": 306,
+                  "end": 312,
+                  "loc": {
+                    "start": {
+                      "line": 12,
+                      "column": 29
+                    },
+                    "end": {
+                      "line": 12,
+                      "column": 35
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "properties": [],
           "indexers": [],
           "exact": false
         }

--- a/test/fixtures/flow/type-annotations/object-type-method/expected.json
+++ b/test/fixtures/flow/type-annotations/object-type-method/expected.json
@@ -1,0 +1,584 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 109,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 26
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 109,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 26
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "TypeAlias",
+        "start": 0,
+        "end": 27,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 27
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 5,
+          "end": 6,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 5
+            },
+            "end": {
+              "line": 1,
+              "column": 6
+            },
+            "identifierName": "T"
+          },
+          "name": "T"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "ObjectTypeAnnotation",
+          "start": 9,
+          "end": 26,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 9
+            },
+            "end": {
+              "line": 1,
+              "column": 26
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 11,
+              "end": 24,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 11
+                },
+                "end": {
+                  "line": 1,
+                  "column": 24
+                }
+              },
+              "key": {
+                "type": "Identifier",
+                "start": 11,
+                "end": 12,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 12
+                  },
+                  "identifierName": "a"
+                },
+                "name": "a"
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 14,
+                "end": 24,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 24
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 20,
+                  "end": 24,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 20
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 24
+                    }
+                  }
+                },
+                "typeParameters": null
+              },
+              "optional": false,
+              "static": false,
+              "variance": null
+            }
+          ],
+          "indexers": [],
+          "exact": false
+        }
+      },
+      {
+        "type": "TypeAlias",
+        "start": 28,
+        "end": 58,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 30
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 33,
+          "end": 34,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 5
+            },
+            "end": {
+              "line": 2,
+              "column": 6
+            },
+            "identifierName": "T"
+          },
+          "name": "T"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "ObjectTypeAnnotation",
+          "start": 37,
+          "end": 57,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 9
+            },
+            "end": {
+              "line": 2,
+              "column": 29
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 39,
+              "end": 55,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 11
+                },
+                "end": {
+                  "line": 2,
+                  "column": 27
+                }
+              },
+              "key": {
+                "type": "Identifier",
+                "start": 39,
+                "end": 40,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 12
+                  },
+                  "identifierName": "a"
+                },
+                "name": "a"
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 42,
+                "end": 55,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 27
+                  }
+                },
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 42,
+                  "end": 45,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 14
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 17
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 43,
+                      "end": 44,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 15
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 16
+                        }
+                      },
+                      "name": "T",
+                      "variance": null
+                    }
+                  ]
+                },
+                "params": [],
+                "rest": null,
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 51,
+                  "end": 55,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 23
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 27
+                    }
+                  }
+                }
+              },
+              "optional": false,
+              "static": false,
+              "variance": null
+            }
+          ],
+          "indexers": [],
+          "exact": false
+        }
+      },
+      {
+        "type": "TypeAlias",
+        "start": 59,
+        "end": 82,
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 23
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 64,
+          "end": 65,
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 5
+            },
+            "end": {
+              "line": 3,
+              "column": 6
+            },
+            "identifierName": "T"
+          },
+          "name": "T"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "ObjectTypeAnnotation",
+          "start": 68,
+          "end": 81,
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 9
+            },
+            "end": {
+              "line": 3,
+              "column": 22
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 70,
+              "end": 79,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 11
+                },
+                "end": {
+                  "line": 3,
+                  "column": 20
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 70,
+                "end": 79,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 20
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": null,
+                "method": true,
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 75,
+                  "end": 79,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 16
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 20
+                    }
+                  }
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 70,
+                "end": 71,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 12
+                  },
+                  "identifierName": "a"
+                },
+                "name": "a"
+              },
+              "optional": false
+            }
+          ],
+          "indexers": [],
+          "exact": false
+        }
+      },
+      {
+        "type": "TypeAlias",
+        "start": 83,
+        "end": 109,
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 26
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 88,
+          "end": 89,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 5
+            },
+            "end": {
+              "line": 4,
+              "column": 6
+            },
+            "identifierName": "T"
+          },
+          "name": "T"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "ObjectTypeAnnotation",
+          "start": 92,
+          "end": 108,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 9
+            },
+            "end": {
+              "line": 4,
+              "column": 25
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 94,
+              "end": 106,
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 11
+                },
+                "end": {
+                  "line": 4,
+                  "column": 23
+                }
+              },
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 94,
+                "end": 106,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 23
+                  }
+                },
+                "params": [],
+                "rest": null,
+                "typeParameters": {
+                  "type": "TypeParameterDeclaration",
+                  "start": 95,
+                  "end": 98,
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 12
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 15
+                    }
+                  },
+                  "params": [
+                    {
+                      "type": "TypeParameter",
+                      "start": 96,
+                      "end": 97,
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 13
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 14
+                        }
+                      },
+                      "name": "T",
+                      "variance": null
+                    }
+                  ]
+                },
+                "method": true,
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 102,
+                  "end": 106,
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 19
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 23
+                    }
+                  }
+                }
+              },
+              "static": false,
+              "key": {
+                "type": "Identifier",
+                "start": 94,
+                "end": 95,
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 12
+                  },
+                  "identifierName": "a"
+                },
+                "name": "a"
+              },
+              "optional": false
+            }
+          ],
+          "indexers": [],
+          "exact": false
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | yes
| Fixed tickets     | #331
| License           | MIT


For distinguishing the two Flow object type fn styles. See #331, will align with Flow.

```js
type T = { a: () => void };
type T = { a(): void };
```

* [ ] Double check Flow's adding `method` to the `FunctionTypeAnnotation` and not the `ObjectTypeAnnotation`
* [x] ~~How about `ObjectTypeCallProperty` which also contains a method-looking `FunctionTypeAnnotation`? `type T = { (): number }` - it's currently `false`~~