### PR TITLE
Remove ForAwaitStatement, add await flag to ForOfStatement

### DIFF
--- a/ast/spec.md
+++ b/ast/spec.md
@@ -35,7 +35,6 @@ These are the core Babylon AST node types.
     - [ForStatement](#forstatement)
     - [ForInStatement](#forinstatement)
     - [ForOfStatement](#forofstatement)
-    - [ForAwaitStatement](#forawaitstatement)
 - [Declarations](#declarations)
   - [FunctionDeclaration](#functiondeclaration)
   - [VariableDeclaration](#variabledeclaration)
@@ -478,16 +477,7 @@ A `for`/`in` statement.
 ```js
 interface ForOfStatement <: ForInStatement {
   type: "ForOfStatement";
-}
-```
-
-A `for`/`await` statement.
-
-## ForAwaitStatement
-
-```js
-interface ForAwaitStatement <: ForInStatement {
-  type: "ForAwaitStatement";
+  await: boolean;
 }
 ```
 

--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -530,12 +530,11 @@ pp.parseFor = function (node, init) {
 // same from parser's perspective.
 
 pp.parseForIn = function (node, init, forAwait) {
-  let type;
+  const type = this.match(tt._in) ? "ForInStatement" : "ForOfStatement";
   if (forAwait) {
+    node.await = true;
     this.eatContextual("of");
-    type = "ForAwaitStatement";
   } else {
-    type = this.match(tt._in) ? "ForInStatement" : "ForOfStatement";
     this.next();
   }
   node.left = init;

--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -532,11 +532,11 @@ pp.parseFor = function (node, init) {
 pp.parseForIn = function (node, init, forAwait) {
   const type = this.match(tt._in) ? "ForInStatement" : "ForOfStatement";
   if (forAwait) {
-    node.await = true;
     this.eatContextual("of");
   } else {
     this.next();
   }
+  node.await = !!forAwait;
   node.left = init;
   node.right = this.parseExpression();
   this.expect(tt.parenR);

--- a/test/fixtures/esprima/es2015-for-of/for-of/expected.json
+++ b/test/fixtures/esprima/es2015-for-of/for-of/expected.json
@@ -32,6 +32,7 @@
         "type": "ForOfStatement",
         "start": 0,
         "end": 13,
+        "await": false,
         "loc": {
           "start": {
             "line": 1,

--- a/test/fixtures/experimental/async-generators/for-await/expected.json
+++ b/test/fixtures/experimental/async-generators/for-await/expected.json
@@ -78,7 +78,7 @@
           },
           "body": [
             {
-              "type": "ForAwaitStatement",
+              "type": "ForOfStatement",
               "start": 23,
               "end": 46,
               "loc": {
@@ -91,6 +91,7 @@
                   "column": 25
                 }
               },
+              "await": true,
               "left": {
                 "type": "VariableDeclaration",
                 "start": 34,


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | yes
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | yes
| Fixed tickets     | https://github.com/babel/babylon/issues/348
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->

Removes the `ForAwaitStatement` node type and adds an `await` flag to the existing `ForOfStatement` node!
