### PR TITLE
Ensure takeDecorators is called on exported class

### DIFF
--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -76,7 +76,6 @@ pp.parseStatement = function (declaration, topLevel) {
 
     case tt._class:
       if (!declaration) this.unexpected();
-      this.takeDecorators(node);
       return this.parseClass(node, true);
 
     case tt._if: return this.parseIfStatement(node);
@@ -618,6 +617,7 @@ pp.parseFunctionParams = function (node) {
 
 pp.parseClass = function (node, isStatement, optionalId) {
   this.next();
+  this.takeDecorators(node);
   this.parseClassId(node, isStatement, optionalId);
   this.parseClassSuper(node);
   this.parseClassBody(node);

--- a/test/fixtures/experimental/decorators/export-default-with-nested-class/actual.js
+++ b/test/fixtures/experimental/decorators/export-default-with-nested-class/actual.js
@@ -1,0 +1,7 @@
+@ParentDecorator
+export default class ParentClass {
+  makeNestedClass() {
+    class NestedClass {
+    }
+  }
+}

--- a/test/fixtures/experimental/decorators/export-default-with-nested-class/expected.json
+++ b/test/fixtures/experimental/decorators/export-default-with-nested-class/expected.json
@@ -1,0 +1,240 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 109,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 7,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 109,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 7,
+        "column": 1
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ExportDefaultDeclaration",
+        "start": 17,
+        "end": 109,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 7,
+            "column": 1
+          }
+        },
+        "declaration": {
+          "type": "ClassDeclaration",
+          "start": 32,
+          "end": 109,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 15
+            },
+            "end": {
+              "line": 7,
+              "column": 1
+            }
+          },
+          "id": {
+            "type": "Identifier",
+            "start": 38,
+            "end": 49,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 21
+              },
+              "end": {
+                "line": 2,
+                "column": 32
+              },
+              "identifierName": "ParentClass"
+            },
+            "name": "ParentClass"
+          },
+          "decorators": [
+            {
+              "type": "Decorator",
+              "start": 0,
+              "end": 16,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 16
+                }
+              },
+              "expression": {
+                "type": "Identifier",
+                "start": 1,
+                "end": 16,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 1
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 16
+                  },
+                  "identifierName": "ParentDecorator"
+                },
+                "name": "ParentDecorator"
+              }
+            }
+          ],
+          "superClass": null,
+          "body": {
+            "type": "ClassBody",
+            "start": 50,
+            "end": 109,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 33
+              },
+              "end": {
+                "line": 7,
+                "column": 1
+              }
+            },
+            "body": [
+              {
+                "type": "ClassMethod",
+                "start": 54,
+                "end": 107,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 3
+                  }
+                },
+                "computed": false,
+                "key": {
+                  "type": "Identifier",
+                  "start": 54,
+                  "end": 69,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 17
+                    },
+                    "identifierName": "makeNestedClass"
+                  },
+                  "name": "makeNestedClass"
+                },
+                "static": false,
+                "kind": "method",
+                "id": null,
+                "generator": false,
+                "expression": false,
+                "async": false,
+                "params": [],
+                "body": {
+                  "type": "BlockStatement",
+                  "start": 72,
+                  "end": 107,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 20
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 3
+                    }
+                  },
+                  "body": [
+                    {
+                      "type": "ClassDeclaration",
+                      "start": 78,
+                      "end": 103,
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 4
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 5
+                        }
+                      },
+                      "id": {
+                        "type": "Identifier",
+                        "start": 84,
+                        "end": 95,
+                        "loc": {
+                          "start": {
+                            "line": 4,
+                            "column": 10
+                          },
+                          "end": {
+                            "line": 4,
+                            "column": 21
+                          },
+                          "identifierName": "NestedClass"
+                        },
+                        "name": "NestedClass"
+                      },
+                      "superClass": null,
+                      "body": {
+                        "type": "ClassBody",
+                        "start": 96,
+                        "end": 103,
+                        "loc": {
+                          "start": {
+                            "line": 4,
+                            "column": 22
+                          },
+                          "end": {
+                            "line": 5,
+                            "column": 5
+                          }
+                        },
+                        "body": []
+                      }
+                    }
+                  ],
+                  "directives": []
+                }
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/experimental/decorators/export-default-with-nested-class/options.json
+++ b/test/fixtures/experimental/decorators/export-default-with-nested-class/options.json
@@ -1,0 +1,3 @@
+{
+  "sourceType": "module"
+}


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes/yes
| Fixed tickets     | Fixes #259
| License           | MIT

Looks like `takeDecorators` wasn't being called on an exported class, so this ensures it is called in both cases.