### PR TITLE
Fix generator-method-with-computed-name test

### DIFF
--- a/test/fixtures/esprima/es2015-generator/generator-method-with-computed-name/actual.js
+++ b/test/fixtures/esprima/es2015-generator/generator-method-with-computed-name/actual.js
@@ -1,3 +1,3 @@
 (function*() {
-    { *[yield iter]() {} }
+    return { *[yield iter]() {} }
 })

--- a/test/fixtures/esprima/es2015-generator/generator-method-with-computed-name/expected.json
+++ b/test/fixtures/esprima/es2015-generator/generator-method-with-computed-name/expected.json
@@ -1,0 +1,197 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 51,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 2
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 51,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 2
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 51,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 2
+          }
+        },
+        "expression": {
+          "type": "FunctionExpression",
+          "start": 1,
+          "end": 50,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 1
+            },
+            "end": {
+              "line": 3,
+              "column": 1
+            }
+          },
+          "id": null,
+          "generator": true,
+          "expression": false,
+          "async": false,
+          "params": [],
+          "body": {
+            "type": "BlockStatement",
+            "start": 13,
+            "end": 50,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 13
+              },
+              "end": {
+                "line": 3,
+                "column": 1
+              }
+            },
+            "body": [
+              {
+                "type": "ReturnStatement",
+                "start": 19,
+                "end": 48,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 33
+                  }
+                },
+                "argument": {
+                  "type": "ObjectExpression",
+                  "start": 26,
+                  "end": 48,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 33
+                    }
+                  },
+                  "properties": [
+                    {
+                      "type": "ObjectMethod",
+                      "start": 28,
+                      "end": 46,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 13
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 31
+                        }
+                      },
+                      "method": true,
+                      "shorthand": false,
+                      "computed": true,
+                      "key": {
+                        "type": "YieldExpression",
+                        "start": 30,
+                        "end": 40,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 15
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 25
+                          }
+                        },
+                        "delegate": false,
+                        "argument": {
+                          "type": "Identifier",
+                          "start": 36,
+                          "end": 40,
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 21
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 25
+                            },
+                            "identifierName": "iter"
+                          },
+                          "name": "iter"
+                        }
+                      },
+                      "kind": "method",
+                      "id": null,
+                      "generator": true,
+                      "expression": false,
+                      "async": false,
+                      "params": [],
+                      "body": {
+                        "type": "BlockStatement",
+                        "start": 44,
+                        "end": 46,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 29
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 31
+                          }
+                        },
+                        "body": [],
+                        "directives": []
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "directives": []
+          },
+          "extra": {
+            "parenthesized": true,
+            "parenStart": 0
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/esprima/es2015-generator/generator-method-with-computed-name/options.json
+++ b/test/fixtures/esprima/es2015-generator/generator-method-with-computed-name/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Unexpected token (2:6)"
-}


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes (test fix)
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | not sure
| Tests added/pass? | yes
| Fixed tickets     | comma-separated list of tickets fixed by the PR, if any
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->

This test was previously checking that a block does not parse as an object, though the intent appeared to be to validate that you can have `[yield iter]` be the key of an object. 

I'm not sure if this is compliant with the spec, or if it makes any sense. If this is indeed supposed to raise an error, I'd be happy to try to submit a patch fixing the parser. 