### PR TITLE
Revert "Don't parse class properties without initializers when classProperties plugin is disabled, and Flow is enabled"

### DIFF
--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -766,13 +766,8 @@ pp.parseClassBody = function (node) {
 };
 
 pp.parseClassProperty = function (node) {
-  const noPluginMsg = "You can only use Class Properties when the 'classProperties' plugin is enabled.";
-  if (!node.typeAnnotation && !this.hasPlugin("classProperties")) {
-    this.raise(node.start, noPluginMsg);
-  }
-
   if (this.match(tt.eq)) {
-    if (!this.hasPlugin("classProperties")) this.raise(this.state.start, noPluginMsg);
+    if (!this.hasPlugin("classProperties")) this.unexpected();
     this.next();
     node.value = this.parseMaybeAssign();
   } else {

--- a/test/fixtures/experimental/class-properties/with-initializer-and-type-no-plugin/actual.js
+++ b/test/fixtures/experimental/class-properties/with-initializer-and-type-no-plugin/actual.js
@@ -1,3 +1,0 @@
-class Foo {
-  bar: string = 'bizz';
-}

--- a/test/fixtures/experimental/class-properties/with-initializer-and-type-no-plugin/options.json
+++ b/test/fixtures/experimental/class-properties/with-initializer-and-type-no-plugin/options.json
@@ -1,4 +1,0 @@
-{
-  "plugins": ["flow"],
-  "throws": "You can only use Class Properties when the 'classProperties' plugin is enabled. (2:14)"
-}

--- a/test/fixtures/experimental/class-properties/with-initializer-missing-plugin/actual.js
+++ b/test/fixtures/experimental/class-properties/with-initializer-missing-plugin/actual.js
@@ -1,3 +1,0 @@
-class Foo {
-  bar = 'bizz';
-}

--- a/test/fixtures/experimental/class-properties/with-initializer-missing-plugin/options.json
+++ b/test/fixtures/experimental/class-properties/with-initializer-missing-plugin/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "You can only use Class Properties when the 'classProperties' plugin is enabled. (2:2)"
-}

--- a/test/fixtures/experimental/class-properties/without-initializer-missing-plugin/actual.js
+++ b/test/fixtures/experimental/class-properties/without-initializer-missing-plugin/actual.js
@@ -1,3 +1,0 @@
-class Foo {
-  bar;
-}

--- a/test/fixtures/experimental/class-properties/without-initializer-missing-plugin/options.json
+++ b/test/fixtures/experimental/class-properties/without-initializer-missing-plugin/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "You can only use Class Properties when the 'classProperties' plugin is enabled. (2:2)"
-}


### PR DESCRIPTION
Reverts babel/babylon#300