### PR TITLE
Don't consume async when checking for async func decl

### DIFF
--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -835,6 +835,13 @@ pp.parseExport = function (node) {
     let needsSemi = false;
     if (this.eat(tt._function)) {
       expr = this.parseFunction(expr, true, false, false, true);
+    } else if (
+      this.isContextual("async") &&
+      this.lookahead().type === tt._function
+    ) { // async function declaration
+      this.eatContextual("async");
+      this.eat(tt._function);
+      expr = this.parseFunction(expr, true, false, true, true);
     } else if (this.match(tt._class)) {
       expr = this.parseClass(expr, true, true);
     } else {

--- a/test/fixtures/es2017/async-functions/export-arrow/actual.js
+++ b/test/fixtures/es2017/async-functions/export-arrow/actual.js
@@ -1,0 +1,1 @@
+export default async () => await foo()

--- a/test/fixtures/es2017/async-functions/export-arrow/expected.json
+++ b/test/fixtures/es2017/async-functions/export-arrow/expected.json
@@ -1,0 +1,117 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 38,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 38
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 38,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 38
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ExportDefaultDeclaration",
+        "start": 0,
+        "end": 38,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 38
+          }
+        },
+        "declaration": {
+          "type": "ArrowFunctionExpression",
+          "start": 15,
+          "end": 38,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 15
+            },
+            "end": {
+              "line": 1,
+              "column": 38
+            }
+          },
+          "id": null,
+          "generator": false,
+          "expression": true,
+          "async": true,
+          "params": [],
+          "body": {
+            "type": "AwaitExpression",
+            "start": 27,
+            "end": 38,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 27
+              },
+              "end": {
+                "line": 1,
+                "column": 38
+              }
+            },
+            "argument": {
+              "type": "CallExpression",
+              "start": 33,
+              "end": 38,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 33
+                },
+                "end": {
+                  "line": 1,
+                  "column": 38
+                }
+              },
+              "callee": {
+                "type": "Identifier",
+                "start": 33,
+                "end": 36,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 33
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 36
+                  },
+                  "identifierName": "foo"
+                },
+                "name": "foo"
+              },
+              "arguments": []
+            }
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/es2017/async-functions/export-arrow/options.json
+++ b/test/fixtures/es2017/async-functions/export-arrow/options.json
@@ -1,0 +1,3 @@
+{
+  "sourceType": "module"
+}

--- a/test/fixtures/es2017/async-functions/export/actual.js
+++ b/test/fixtures/es2017/async-functions/export/actual.js
@@ -1,0 +1,2 @@
+export async function foo() {}
+export default async function bar() {}

--- a/test/fixtures/es2017/async-functions/export/expected.json
+++ b/test/fixtures/es2017/async-functions/export/expected.json
@@ -1,0 +1,172 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 69,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 38
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 69,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 38
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 0,
+        "end": 30,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 30
+          }
+        },
+        "specifiers": [],
+        "source": null,
+        "declaration": {
+          "type": "FunctionDeclaration",
+          "start": 7,
+          "end": 30,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 1,
+              "column": 30
+            }
+          },
+          "id": {
+            "type": "Identifier",
+            "start": 22,
+            "end": 25,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 22
+              },
+              "end": {
+                "line": 1,
+                "column": 25
+              },
+              "identifierName": "foo"
+            },
+            "name": "foo"
+          },
+          "generator": false,
+          "expression": false,
+          "async": true,
+          "params": [],
+          "body": {
+            "type": "BlockStatement",
+            "start": 28,
+            "end": 30,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 28
+              },
+              "end": {
+                "line": 1,
+                "column": 30
+              }
+            },
+            "body": [],
+            "directives": []
+          }
+        }
+      },
+      {
+        "type": "ExportDefaultDeclaration",
+        "start": 31,
+        "end": 69,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 38
+          }
+        },
+        "declaration": {
+          "type": "FunctionDeclaration",
+          "start": 46,
+          "end": 69,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 15
+            },
+            "end": {
+              "line": 2,
+              "column": 38
+            }
+          },
+          "id": {
+            "type": "Identifier",
+            "start": 61,
+            "end": 64,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 30
+              },
+              "end": {
+                "line": 2,
+                "column": 33
+              },
+              "identifierName": "bar"
+            },
+            "name": "bar"
+          },
+          "generator": false,
+          "expression": false,
+          "async": true,
+          "params": [],
+          "body": {
+            "type": "BlockStatement",
+            "start": 67,
+            "end": 69,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 36
+              },
+              "end": {
+                "line": 2,
+                "column": 38
+              }
+            },
+            "body": [],
+            "directives": []
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/es2017/async-functions/export/options.json
+++ b/test/fixtures/es2017/async-functions/export/options.json
@@ -1,0 +1,3 @@
+{
+  "sourceType": "module"
+}


### PR DESCRIPTION
As reported in https://github.com/babel/babel/issues/5366.