### PR TITLE
Improves error message when super is called outside of constructor

### DIFF
--- a/src/parser/expression.js
+++ b/src/parser/expression.js
@@ -392,7 +392,7 @@ pp.parseExprAtom = function (refShorthandDefaultPos) {
         this.unexpected();
       }
       if (this.match(tt.parenL) && this.state.inMethod !== "constructor" && !this.options.allowSuperOutsideMethod) {
-        this.raise(node.start, "super() outside of class constructor");
+        this.raise(node.start, "super() is only valid inside a class constructor. Make sure the method name is spelled exactly as 'constructor' and has no typos");
       }
       return this.finishNode(node, "Super");
 

--- a/src/parser/expression.js
+++ b/src/parser/expression.js
@@ -392,7 +392,7 @@ pp.parseExprAtom = function (refShorthandDefaultPos) {
         this.unexpected();
       }
       if (this.match(tt.parenL) && this.state.inMethod !== "constructor" && !this.options.allowSuperOutsideMethod) {
-        this.raise(node.start, "super() is only valid inside a class constructor. Make sure the method name is spelled exactly as 'constructor' and has no typos");
+        this.raise(node.start, "super() is only valid inside a class constructor. Make sure the method name is spelled exactly as 'constructor'.");
       }
       return this.finishNode(node, "Super");
 

--- a/test/fixtures/es2015/class-methods/direct-super-outside-constructor/options.json
+++ b/test/fixtures/es2015/class-methods/direct-super-outside-constructor/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "super() is only valid inside a class constructor. Make sure the method name is spelled exactly as 'constructor' and has no typos (2:8)"
+  "throws": "super() is only valid inside a class constructor. Make sure the method name is spelled exactly as 'constructor'. (2:8)"
 }

--- a/test/fixtures/es2015/class-methods/direct-super-outside-constructor/options.json
+++ b/test/fixtures/es2015/class-methods/direct-super-outside-constructor/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "super() outside of class constructor (2:8)"
+  "throws": "super() is only valid inside a class constructor. Make sure the method name is spelled exactly as 'constructor' and has no typos (2:8)"
 }


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->

This PR improves the error message thrown when `super()` is used outside of the `constructor` method. 

Many developers coming from Java background use the name of the class itself as the constructor method name. Also sometimes the developers make a typo like `constructr` or `contructor` and wonder what is the issue. This message would help them in understanding the issue and fix it faster.

Opened a PR on babel [here](https://github.com/babel/babel/pull/5450) to make sure that the tests pass there as well when this PR is merged