### PR TITLE
Fix predicate handling to match flow parser

### DIFF
--- a/src/plugins/flow.js
+++ b/src/plugins/flow.js
@@ -40,7 +40,7 @@ pp.flowParsePredicate = function() {
     this.raise(moduloPos, "Spaces between ´%´ and ´checks´ are not allowed here.");
   }
   if (this.eat(tt.parenL)) {
-    node.expression = this.parseExpression();
+    node.value = this.parseExpression();
     this.expect(tt.parenR);
     return this.finishNode(node, "DeclaredPredicate");
   } else {
@@ -92,10 +92,10 @@ pp.flowParseDeclareFunction = function (node) {
   typeNode.params = tmp.params;
   typeNode.rest = tmp.rest;
   this.expect(tt.parenR);
-  let predicate = null;
-  [typeNode.returnType, predicate] = this.flowParseTypeAndPredicateInitialiser();
+
+  [typeNode.returnType, node.predicate] = this.flowParseTypeAndPredicateInitialiser();
   typeContainer.typeAnnotation = this.finishNode(typeNode, "FunctionTypeAnnotation");
-  typeContainer.predicate = predicate;
+
   id.typeAnnotation = this.finishNode(typeContainer, "TypeAnnotation");
 
   this.finishNode(id, id.type);
@@ -820,12 +820,6 @@ pp.flowParseTypeAnnotation = function () {
   return this.finishNode(node, "TypeAnnotation");
 };
 
-pp.flowParseTypeAndPredicateAnnotation = function () {
-  const node = this.startNode();
-  [node.typeAnnotation, node.predicate] = this.flowParseTypeAndPredicateInitialiser();
-  return this.finishNode(node, "TypeAnnotation");
-};
-
 pp.flowParseTypeAnnotatableIdentifier = function () {
   const ident = this.flowParseRestrictedIdentifier();
   if (this.match(tt.colon)) {
@@ -868,7 +862,12 @@ export default function (instance) {
       if (this.match(tt.colon) && !allowExpression) {
         // if allowExpression is true then we're parsing an arrow function and if
         // there's a return type then it's been handled elsewhere
-        node.returnType = this.flowParseTypeAndPredicateAnnotation();
+        const typeNode = this.startNode();
+        [typeNode.typeAnnotation, node.predicate] = this.flowParseTypeAndPredicateInitialiser();
+
+        node.returnType = typeNode.typeAnnotation
+          ? this.finishNode(typeNode, "TypeAnnotation")
+          : null;
       }
 
       return inner.call(this, node, allowExpression);
@@ -1421,13 +1420,19 @@ export default function (instance) {
         try {
           const oldNoAnonFunctionType = this.state.noAnonFunctionType;
           this.state.noAnonFunctionType = true;
-          const returnType = this.flowParseTypeAndPredicateAnnotation();
+
+          const typeNode = this.startNode();
+          [typeNode.typeAnnotation, node.predicate] = this.flowParseTypeAndPredicateInitialiser();
+
           this.state.noAnonFunctionType = oldNoAnonFunctionType;
 
           if (this.canInsertSemicolon()) this.unexpected();
           if (!this.match(tt.arrow)) this.unexpected();
+
           // assign after it is clear it is an arrow
-          node.returnType = returnType;
+          node.returnType = typeNode.typeAnnotation
+            ? this.finishNode(typeNode, "TypeAnnotation")
+            : null;
         } catch (err) {
           if (err instanceof SyntaxError) {
             this.state = state;

--- a/test/fixtures/flow/anonymous-function-no-parens-types/good_03/expected.json
+++ b/test/fixtures/flow/anonymous-function-no-parens-types/good_03/expected.json
@@ -88,6 +88,7 @@
                   "column": 25
                 }
               },
+              "predicate": null,
               "returnType": {
                 "type": "TypeAnnotation",
                 "start": 10,
@@ -116,8 +117,7 @@
                       "column": 18
                     }
                   }
-                },
-                "predicate": null
+                }
               },
               "id": null,
               "generator": false,

--- a/test/fixtures/flow/anonymous-function-no-parens-types/good_04/expected.json
+++ b/test/fixtures/flow/anonymous-function-no-parens-types/good_04/expected.json
@@ -88,6 +88,7 @@
                   "column": 34
                 }
               },
+              "predicate": null,
               "returnType": {
                 "type": "TypeAnnotation",
                 "start": 10,
@@ -148,8 +149,7 @@
                       }
                     }
                   ]
-                },
-                "predicate": null
+                }
               },
               "id": null,
               "generator": false,

--- a/test/fixtures/flow/anonymous-function-no-parens-types/good_05/expected.json
+++ b/test/fixtures/flow/anonymous-function-no-parens-types/good_05/expected.json
@@ -88,6 +88,7 @@
                   "column": 35
                 }
               },
+              "predicate": null,
               "returnType": {
                 "type": "TypeAnnotation",
                 "start": 11,
@@ -184,8 +185,7 @@
                     "value": 123
                   },
                   "typeParameters": null
-                },
-                "predicate": null
+                }
               },
               "id": null,
               "generator": false,

--- a/test/fixtures/flow/anonymous-function-types/good_01/expected.json
+++ b/test/fixtures/flow/anonymous-function-types/good_01/expected.json
@@ -185,10 +185,10 @@
                   }
                 }
               }
-            },
-            "predicate": null
+            }
           }
-        }
+        },
+        "predicate": null
       }
     ],
     "directives": []

--- a/test/fixtures/flow/anonymous-function-types/good_10/expected.json
+++ b/test/fixtures/flow/anonymous-function-types/good_10/expected.json
@@ -88,6 +88,7 @@
                   "column": 38
                 }
               },
+              "predicate": null,
               "returnType": {
                 "type": "TypeAnnotation",
                 "start": 11,
@@ -188,8 +189,7 @@
                     "value": 123
                   },
                   "typeParameters": null
-                },
-                "predicate": null
+                }
               },
               "id": null,
               "generator": false,

--- a/test/fixtures/flow/anonymous-function-types/good_11/expected.json
+++ b/test/fixtures/flow/anonymous-function-types/good_11/expected.json
@@ -88,6 +88,7 @@
                   "column": 27
                 }
               },
+              "predicate": null,
               "returnType": {
                 "type": "TypeAnnotation",
                 "start": 10,
@@ -116,8 +117,7 @@
                       "column": 19
                     }
                   }
-                },
-                "predicate": null
+                }
               },
               "id": null,
               "generator": false,

--- a/test/fixtures/flow/anonymous-function-types/good_12/expected.json
+++ b/test/fixtures/flow/anonymous-function-types/good_12/expected.json
@@ -88,6 +88,7 @@
                   "column": 36
                 }
               },
+              "predicate": null,
               "returnType": {
                 "type": "TypeAnnotation",
                 "start": 10,
@@ -148,8 +149,7 @@
                       }
                     }
                   ]
-                },
-                "predicate": null
+                }
               },
               "id": null,
               "generator": false,

--- a/test/fixtures/flow/anonymous-function-types/good_13/expected.json
+++ b/test/fixtures/flow/anonymous-function-types/good_13/expected.json
@@ -88,6 +88,7 @@
                   "column": 37
                 }
               },
+              "predicate": null,
               "returnType": {
                 "type": "TypeAnnotation",
                 "start": 11,
@@ -178,8 +179,7 @@
                     "value": 123
                   },
                   "typeParameters": null
-                },
-                "predicate": null
+                }
               },
               "id": null,
               "generator": false,

--- a/test/fixtures/flow/anonymous-function-types/good_14/expected.json
+++ b/test/fixtures/flow/anonymous-function-types/good_14/expected.json
@@ -88,6 +88,7 @@
                   "column": 25
                 }
               },
+              "predicate": null,
               "returnType": {
                 "type": "TypeAnnotation",
                 "start": 11,
@@ -158,8 +159,7 @@
                       "value": 2
                     }
                   ]
-                },
-                "predicate": null
+                }
               },
               "id": null,
               "generator": false,

--- a/test/fixtures/flow/declare-module/4/expected.json
+++ b/test/fixtures/flow/declare-module/4/expected.json
@@ -150,10 +150,10 @@
                         }
                       }
                     }
-                  },
-                  "predicate": null
+                  }
                 }
-              }
+              },
+              "predicate": null
             }
           ]
         }

--- a/test/fixtures/flow/declare-statements/3/expected.json
+++ b/test/fixtures/flow/declare-statements/3/expected.json
@@ -104,10 +104,10 @@
                   }
                 }
               }
-            },
-            "predicate": null
+            }
           }
-        }
+        },
+        "predicate": null
       }
     ],
     "directives": []

--- a/test/fixtures/flow/declare-statements/4/expected.json
+++ b/test/fixtures/flow/declare-statements/4/expected.json
@@ -104,10 +104,10 @@
                   }
                 }
               }
-            },
-            "predicate": null
+            }
           }
-        }
+        },
+        "predicate": null
       }
     ],
     "directives": []

--- a/test/fixtures/flow/declare-statements/5/expected.json
+++ b/test/fixtures/flow/declare-statements/5/expected.json
@@ -137,10 +137,10 @@
                   }
                 }
               }
-            },
-            "predicate": null
+            }
           }
-        }
+        },
+        "predicate": null
       }
     ],
     "directives": []

--- a/test/fixtures/flow/declare-statements/6/expected.json
+++ b/test/fixtures/flow/declare-statements/6/expected.json
@@ -201,10 +201,10 @@
                   }
                 }
               }
-            },
-            "predicate": null
+            }
           }
-        }
+        },
+        "predicate": null
       }
     ],
     "directives": []

--- a/test/fixtures/flow/literal-types/string-double/expected.json
+++ b/test/fixtures/flow/literal-types/string-double/expected.json
@@ -162,9 +162,9 @@
               },
               "name": "HTMLDivElement"
             }
-          },
-          "predicate": null
+          }
         },
+        "predicate": null,
         "body": {
           "type": "BlockStatement",
           "start": 55,

--- a/test/fixtures/flow/literal-types/string-single/expected.json
+++ b/test/fixtures/flow/literal-types/string-single/expected.json
@@ -162,9 +162,9 @@
               },
               "name": "HTMLDivElement"
             }
-          },
-          "predicate": null
+          }
         },
+        "predicate": null,
         "body": {
           "type": "BlockStatement",
           "start": 55,

--- a/test/fixtures/flow/predicates/1/expected.json
+++ b/test/fixtures/flow/predicates/1/expected.json
@@ -153,67 +153,67 @@
                   }
                 }
               }
+            }
+          }
+        },
+        "predicate": {
+          "type": "DeclaredPredicate",
+          "start": 40,
+          "end": 59,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 40
             },
-            "predicate": {
-              "type": "DeclaredPredicate",
-              "start": 40,
-              "end": 59,
+            "end": {
+              "line": 1,
+              "column": 59
+            }
+          },
+          "value": {
+            "type": "BinaryExpression",
+            "start": 48,
+            "end": 58,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 48
+              },
+              "end": {
+                "line": 1,
+                "column": 58
+              }
+            },
+            "left": {
+              "type": "Identifier",
+              "start": 48,
+              "end": 49,
               "loc": {
                 "start": {
                   "line": 1,
-                  "column": 40
+                  "column": 48
                 },
                 "end": {
                   "line": 1,
-                  "column": 59
-                }
+                  "column": 49
+                },
+                "identifierName": "x"
               },
-              "expression": {
-                "type": "BinaryExpression",
-                "start": 48,
-                "end": 58,
-                "loc": {
-                  "start": {
-                    "line": 1,
-                    "column": 48
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 58
-                  }
+              "name": "x"
+            },
+            "operator": "!==",
+            "right": {
+              "type": "NullLiteral",
+              "start": 54,
+              "end": 58,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 54
                 },
-                "left": {
-                  "type": "Identifier",
-                  "start": 48,
-                  "end": 49,
-                  "loc": {
-                    "start": {
-                      "line": 1,
-                      "column": 48
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 49
-                    },
-                    "identifierName": "x"
-                  },
-                  "name": "x"
-                },
-                "operator": "!==",
-                "right": {
-                  "type": "NullLiteral",
-                  "start": 54,
-                  "end": 58,
-                  "loc": {
-                    "start": {
-                      "line": 1,
-                      "column": 54
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 58
-                    }
-                  }
+                "end": {
+                  "line": 1,
+                  "column": 58
                 }
               }
             }

--- a/test/fixtures/flow/predicates/2/expected.json
+++ b/test/fixtures/flow/predicates/2/expected.json
@@ -88,37 +88,22 @@
                   "column": 52
                 }
               },
-              "returnType": {
-                "type": "TypeAnnotation",
-                "start": 18,
+              "predicate": {
+                "type": "InferredPredicate",
+                "start": 20,
                 "end": 27,
                 "loc": {
                   "start": {
                     "line": 1,
-                    "column": 18
+                    "column": 20
                   },
                   "end": {
                     "line": 1,
                     "column": 27
                   }
-                },
-                "typeAnnotation": null,
-                "predicate": {
-                  "type": "InferredPredicate",
-                  "start": 20,
-                  "end": 27,
-                  "loc": {
-                    "start": {
-                      "line": 1,
-                      "column": 20
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 27
-                    }
-                  }
                 }
               },
+              "returnType": null,
               "id": null,
               "generator": false,
               "expression": true,

--- a/test/fixtures/flow/predicates/3/expected.json
+++ b/test/fixtures/flow/predicates/3/expected.json
@@ -111,37 +111,22 @@
             }
           }
         ],
-        "returnType": {
-          "type": "TypeAnnotation",
-          "start": 22,
+        "predicate": {
+          "type": "InferredPredicate",
+          "start": 24,
           "end": 31,
           "loc": {
             "start": {
               "line": 1,
-              "column": 22
+              "column": 24
             },
             "end": {
               "line": 1,
               "column": 31
             }
-          },
-          "typeAnnotation": null,
-          "predicate": {
-            "type": "InferredPredicate",
-            "start": 24,
-            "end": 31,
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 24
-              },
-              "end": {
-                "line": 1,
-                "column": 31
-              }
-            }
           }
         },
+        "returnType": null,
         "body": {
           "type": "BlockStatement",
           "start": 32,

--- a/test/fixtures/flow/predicates/6/expected.json
+++ b/test/fixtures/flow/predicates/6/expected.json
@@ -589,10 +589,10 @@
                   "name": "Array"
                 }
               }
-            },
-            "predicate": null
+            }
           }
-        }
+        },
+        "predicate": null
       }
     ],
     "directives": []

--- a/test/fixtures/flow/regression/issue-2493/expected.json
+++ b/test/fixtures/flow/regression/issue-2493/expected.json
@@ -88,6 +88,7 @@
                   "column": 1
                 }
               },
+              "predicate": null,
               "returnType": {
                 "type": "TypeAnnotation",
                 "start": 41,
@@ -116,8 +117,7 @@
                       "column": 49
                     }
                   }
-                },
-                "predicate": null
+                }
               },
               "id": null,
               "generator": false,

--- a/test/fixtures/flow/trailing-function-commas-type/1/expected.json
+++ b/test/fixtures/flow/trailing-function-commas-type/1/expected.json
@@ -56,6 +56,7 @@
               "column": 42
             }
           },
+          "predicate": null,
           "returnType": {
             "type": "TypeAnnotation",
             "start": 21,
@@ -102,8 +103,7 @@
                 },
                 "name": "ReturnType"
               }
-            },
-            "predicate": null
+            }
           },
           "id": null,
           "generator": false,

--- a/test/fixtures/flow/type-annotations/100/expected.json
+++ b/test/fixtures/flow/type-annotations/100/expected.json
@@ -143,9 +143,9 @@
                     }
                   },
                   "value": true
-                },
-                "predicate": null
+                }
               },
+              "predicate": null,
               "body": {
                 "type": "BlockStatement",
                 "start": 23,

--- a/test/fixtures/flow/type-annotations/101/expected.json
+++ b/test/fixtures/flow/type-annotations/101/expected.json
@@ -56,6 +56,7 @@
               "column": 45
             }
           },
+          "predicate": null,
           "returnType": {
             "type": "TypeAnnotation",
             "start": 23,
@@ -117,8 +118,7 @@
                   "name": "ReturnType"
                 }
               }
-            },
-            "predicate": null
+            }
           },
           "id": null,
           "generator": false,

--- a/test/fixtures/flow/type-annotations/102/expected.json
+++ b/test/fixtures/flow/type-annotations/102/expected.json
@@ -56,6 +56,7 @@
               "column": 50
             }
           },
+          "predicate": null,
           "returnType": {
             "type": "TypeAnnotation",
             "start": 29,
@@ -133,8 +134,7 @@
                 },
                 "name": "Array"
               }
-            },
-            "predicate": null
+            }
           },
           "id": null,
           "generator": false,

--- a/test/fixtures/flow/type-annotations/103/expected.json
+++ b/test/fixtures/flow/type-annotations/103/expected.json
@@ -88,6 +88,7 @@
                   "column": 73
                 }
               },
+              "predicate": null,
               "returnType": {
                 "type": "TypeAnnotation",
                 "start": 65,
@@ -134,8 +135,7 @@
                     },
                     "name": "a"
                   }
-                },
-                "predicate": null
+                }
               },
               "id": null,
               "generator": false,

--- a/test/fixtures/flow/type-annotations/12/expected.json
+++ b/test/fixtures/flow/type-annotations/12/expected.json
@@ -91,9 +91,9 @@
                 "column": 21
               }
             }
-          },
-          "predicate": null
+          }
         },
+        "predicate": null,
         "body": {
           "type": "BlockStatement",
           "start": 21,

--- a/test/fixtures/flow/type-annotations/13/expected.json
+++ b/test/fixtures/flow/type-annotations/13/expected.json
@@ -109,9 +109,9 @@
               }
             },
             "typeParameters": null
-          },
-          "predicate": null
+          }
         },
+        "predicate": null,
         "body": {
           "type": "BlockStatement",
           "start": 25,

--- a/test/fixtures/flow/type-annotations/130/expected.json
+++ b/test/fixtures/flow/type-annotations/130/expected.json
@@ -270,9 +270,9 @@
                 "column": 42
               }
             }
-          },
-          "predicate": null
+          }
         },
+        "predicate": null,
         "body": {
           "type": "BlockStatement",
           "start": 43,

--- a/test/fixtures/flow/type-annotations/14/expected.json
+++ b/test/fixtures/flow/type-annotations/14/expected.json
@@ -158,9 +158,9 @@
               }
             },
             "typeParameters": null
-          },
-          "predicate": null
+          }
         },
+        "predicate": null,
         "body": {
           "type": "BlockStatement",
           "start": 33,

--- a/test/fixtures/flow/type-annotations/15/expected.json
+++ b/test/fixtures/flow/type-annotations/15/expected.json
@@ -158,9 +158,9 @@
               }
             },
             "typeParameters": null
-          },
-          "predicate": null
+          }
         },
+        "predicate": null,
         "body": {
           "type": "BlockStatement",
           "start": 34,

--- a/test/fixtures/flow/type-annotations/16/expected.json
+++ b/test/fixtures/flow/type-annotations/16/expected.json
@@ -95,9 +95,9 @@
             "properties": [],
             "indexers": [],
             "exact": false
-          },
-          "predicate": null
+          }
         },
+        "predicate": null,
         "body": {
           "type": "BlockStatement",
           "start": 19,

--- a/test/fixtures/flow/type-annotations/21/expected.json
+++ b/test/fixtures/flow/type-annotations/21/expected.json
@@ -206,9 +206,9 @@
                         "column": 33
                       }
                     }
-                  },
-                  "predicate": null
+                  }
                 },
+                "predicate": null,
                 "body": {
                   "type": "BlockStatement",
                   "start": 33,

--- a/test/fixtures/flow/type-annotations/22/expected.json
+++ b/test/fixtures/flow/type-annotations/22/expected.json
@@ -158,9 +158,9 @@
                         "column": 23
                       }
                     }
-                  },
-                  "predicate": null
+                  }
                 },
+                "predicate": null,
                 "body": {
                   "type": "BlockStatement",
                   "start": 23,

--- a/test/fixtures/flow/type-annotations/23/expected.json
+++ b/test/fixtures/flow/type-annotations/23/expected.json
@@ -241,9 +241,9 @@
                       },
                       "name": "T"
                     }
-                  },
-                  "predicate": null
+                  }
                 },
+                "predicate": null,
                 "body": {
                   "type": "BlockStatement",
                   "start": 18,

--- a/test/fixtures/flow/type-annotations/24/expected.json
+++ b/test/fixtures/flow/type-annotations/24/expected.json
@@ -241,9 +241,9 @@
                       },
                       "name": "T"
                     }
-                  },
-                  "predicate": null
+                  }
                 },
+                "predicate": null,
                 "body": {
                   "type": "BlockStatement",
                   "start": 19,

--- a/test/fixtures/flow/type-annotations/25/expected.json
+++ b/test/fixtures/flow/type-annotations/25/expected.json
@@ -241,9 +241,9 @@
                       },
                       "name": "T"
                     }
-                  },
-                  "predicate": null
+                  }
                 },
+                "predicate": null,
                 "body": {
                   "type": "BlockStatement",
                   "start": 24,

--- a/test/fixtures/flow/type-annotations/26/expected.json
+++ b/test/fixtures/flow/type-annotations/26/expected.json
@@ -244,9 +244,9 @@
                       },
                       "name": "T"
                     }
-                  },
-                  "predicate": null
+                  }
                 },
+                "predicate": null,
                 "body": {
                   "type": "BlockStatement",
                   "start": 19,

--- a/test/fixtures/flow/type-annotations/28/expected.json
+++ b/test/fixtures/flow/type-annotations/28/expected.json
@@ -190,9 +190,9 @@
                       "column": 41
                     }
                   }
-                },
-                "predicate": null
+                }
               },
+              "predicate": null,
               "body": {
                 "type": "BlockStatement",
                 "start": 41,

--- a/test/fixtures/flow/type-annotations/29/expected.json
+++ b/test/fixtures/flow/type-annotations/29/expected.json
@@ -142,9 +142,9 @@
                       "column": 31
                     }
                   }
-                },
-                "predicate": null
+                }
               },
+              "predicate": null,
               "body": {
                 "type": "BlockStatement",
                 "start": 31,

--- a/test/fixtures/flow/type-annotations/50/expected.json
+++ b/test/fixtures/flow/type-annotations/50/expected.json
@@ -210,9 +210,9 @@
                       "column": 30
                     }
                   }
-                },
-                "predicate": null
+                }
               },
+              "predicate": null,
               "body": {
                 "type": "BlockStatement",
                 "start": 31,

--- a/test/fixtures/flow/type-annotations/67/expected.json
+++ b/test/fixtures/flow/type-annotations/67/expected.json
@@ -88,6 +88,7 @@
                   "column": 27
                 }
               },
+              "predicate": null,
               "returnType": {
                 "type": "TypeAnnotation",
                 "start": 12,
@@ -116,8 +117,7 @@
                       "column": 20
                     }
                   }
-                },
-                "predicate": null
+                }
               },
               "id": null,
               "generator": false,

--- a/test/fixtures/flow/type-annotations/68/expected.json
+++ b/test/fixtures/flow/type-annotations/68/expected.json
@@ -88,6 +88,7 @@
                   "column": 30
                 }
               },
+              "predicate": null,
               "returnType": {
                 "type": "TypeAnnotation",
                 "start": 15,
@@ -116,8 +117,7 @@
                       "column": 23
                     }
                   }
-                },
-                "predicate": null
+                }
               },
               "id": null,
               "generator": false,

--- a/test/fixtures/flow/type-annotations/72/expected.json
+++ b/test/fixtures/flow/type-annotations/72/expected.json
@@ -88,6 +88,7 @@
                   "column": 28
                 }
               },
+              "predicate": null,
               "returnType": {
                 "type": "TypeAnnotation",
                 "start": 13,
@@ -116,8 +117,7 @@
                       "column": 21
                     }
                   }
-                },
-                "predicate": null
+                }
               },
               "id": null,
               "generator": false,

--- a/test/fixtures/flow/type-annotations/73/expected.json
+++ b/test/fixtures/flow/type-annotations/73/expected.json
@@ -88,6 +88,7 @@
                   "column": 31
                 }
               },
+              "predicate": null,
               "returnType": {
                 "type": "TypeAnnotation",
                 "start": 16,
@@ -116,8 +117,7 @@
                       "column": 24
                     }
                   }
-                },
-                "predicate": null
+                }
               },
               "id": null,
               "generator": false,

--- a/test/fixtures/flow/type-annotations/74/expected.json
+++ b/test/fixtures/flow/type-annotations/74/expected.json
@@ -102,6 +102,7 @@
                     "column": 32
                   }
                 },
+                "predicate": null,
                 "returnType": {
                   "type": "TypeAnnotation",
                   "start": 17,
@@ -130,8 +131,7 @@
                         "column": 25
                       }
                     }
-                  },
-                  "predicate": null
+                  }
                 },
                 "id": null,
                 "generator": false,

--- a/test/fixtures/flow/type-annotations/79/expected.json
+++ b/test/fixtures/flow/type-annotations/79/expected.json
@@ -119,6 +119,7 @@
                     "column": 36
                   }
                 },
+                "predicate": null,
                 "returnType": {
                   "type": "TypeAnnotation",
                   "start": 22,
@@ -147,8 +148,7 @@
                         "column": 30
                       }
                     }
-                  },
-                  "predicate": null
+                  }
                 },
                 "id": null,
                 "generator": false,

--- a/test/fixtures/flow/type-annotations/99/expected.json
+++ b/test/fixtures/flow/type-annotations/99/expected.json
@@ -56,6 +56,7 @@
               "column": 21
             }
           },
+          "predicate": null,
           "returnType": {
             "type": "TypeAnnotation",
             "start": 10,
@@ -102,8 +103,7 @@
                 },
                 "name": "z"
               }
-            },
-            "predicate": null
+            }
           },
           "id": null,
           "generator": false,

--- a/test/fixtures/flow/type-annotations/arrow-func-return-newline/expected.json
+++ b/test/fixtures/flow/type-annotations/arrow-func-return-newline/expected.json
@@ -88,6 +88,7 @@
                   "column": 14
                 }
               },
+              "predicate": null,
               "returnType": {
                 "type": "TypeAnnotation",
                 "start": 24,
@@ -116,8 +117,7 @@
                       "column": 8
                     }
                   }
-                },
-                "predicate": null
+                }
               },
               "id": null,
               "generator": false,

--- a/test/fixtures/flow/type-annotations/existential-type-param-2/expected.json
+++ b/test/fixtures/flow/type-annotations/existential-type-param-2/expected.json
@@ -118,6 +118,7 @@
                   "column": 38
                 }
               },
+              "predicate": null,
               "returnType": {
                 "type": "TypeAnnotation",
                 "start": 27,
@@ -146,8 +147,7 @@
                       "column": 31
                     }
                   }
-                },
-                "predicate": null
+                }
               },
               "id": null,
               "generator": false,


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes/yes
| Fixed tickets     | 
| License           | MIT

While digging through babylon/flow differences in prettier, noticed a few differences. This PR changes our output to match flow in the following:

- We're handling predicates differently in a number of cases
- Rename `expression` to `value` on `DeclaredPredicate`

Could use a review from @panagosg7 @gabelevi @samwgoldman on making sure we're all in sync here (and I didn't get too cross eyed :D)!