### PR TITLE
Spec fix as BindExpression only have a single object/callee not an Array

### DIFF
--- a/ast/spec.md
+++ b/ast/spec.md
@@ -855,8 +855,8 @@ A member expression. If `computed` is `true`, the node corresponds to a computed
 ```js
 interface BindExpression <: Expression {
     type: "BindExpression";
-    object: [ Expression | null ];
-    callee: [ Expression ]
+    object: Expression | null
+    callee: Expression
 }
 ```
 

--- a/ast/spec.md
+++ b/ast/spec.md
@@ -855,8 +855,8 @@ A member expression. If `computed` is `true`, the node corresponds to a computed
 ```js
 interface BindExpression <: Expression {
     type: "BindExpression";
-    object: Expression | null
-    callee: Expression
+    object: Expression | null;
+    callee: Expression;
 }
 ```
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | N/A
| Fixed tickets     |
| License           | MIT

Basically BindExpression in the spec wraps the properties in an Array, but Babylon just returns a single item (which is what makes sense anyway).
