### PR TITLE
Add support for Flow declare export (default)

### DIFF
--- a/src/plugins/flow.js
+++ b/src/plugins/flow.js
@@ -105,7 +105,7 @@ pp.flowParseDeclareFunction = function (node) {
   return this.finishNode(node, "DeclareFunction");
 };
 
-let flowParseDeclareOrType = function(node, allowModule, allowType) {
+function flowParseDeclareOrType(node, allowModule, allowType) {
   if (this.isContextual("module")) {
     if (!allowModule) {
       this.unexpected();
@@ -137,7 +137,7 @@ let flowParseDeclareOrType = function(node, allowModule, allowType) {
   } else {
     this.unexpected();
   }
-};
+}
 
 pp.flowParseDeclare = function (node) {
   return flowParseDeclareOrType.call(this, node, true, false);

--- a/src/plugins/flow.js
+++ b/src/plugins/flow.js
@@ -191,7 +191,8 @@ pp.flowParseDeclareExport = function (node) {
   const declarationNode = this.startNode();
   node.declaration = flowParseDeclareOrType.call(this, declarationNode, false, false);
   this.semicolon();
-  return this.finishNode(node, "DeclareExport");
+  node.default = false;
+  return this.finishNode(node, "DeclareExportDeclaration");
 };
 
 pp.flowParseDeclareExportDefault = function (node) {
@@ -200,7 +201,8 @@ pp.flowParseDeclareExportDefault = function (node) {
   const declarationNode = this.startNode();
   node.declaration = flowParseDeclareOrType.call(this, declarationNode, false, true);
   this.semicolon();
-  return this.finishNode(node, "DeclareExportDefault");
+  node.default = true;
+  return this.finishNode(node, "DeclareExportDeclaration");
 };
 
 pp.flowParseDeclareModuleExports = function (node) {

--- a/test/fixtures/flow/declare-module/10/actual.js
+++ b/test/fixtures/flow/declare-module/10/actual.js
@@ -1,0 +1,1 @@
+declare module A { declare export default number; }

--- a/test/fixtures/flow/declare-module/10/expected.json
+++ b/test/fixtures/flow/declare-module/10/expected.json
@@ -75,7 +75,7 @@
           },
           "body": [
             {
-              "type": "DeclareExportDefault",
+              "type": "DeclareExportDeclaration",
               "start": 19,
               "end": 49,
               "loc": {
@@ -102,7 +102,8 @@
                     "column": 48
                   }
                 }
-              }
+              },
+              "default": true
             }
           ]
         }

--- a/test/fixtures/flow/declare-module/10/expected.json
+++ b/test/fixtures/flow/declare-module/10/expected.json
@@ -1,0 +1,113 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 51,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 51
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 51,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 51
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "DeclareModule",
+        "start": 0,
+        "end": 51,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 51
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 15,
+          "end": 16,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 15
+            },
+            "end": {
+              "line": 1,
+              "column": 16
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "body": {
+          "type": "BlockStatement",
+          "start": 17,
+          "end": 51,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 17
+            },
+            "end": {
+              "line": 1,
+              "column": 51
+            }
+          },
+          "body": [
+            {
+              "type": "DeclareExportDefault",
+              "start": 19,
+              "end": 49,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 19
+                },
+                "end": {
+                  "line": 1,
+                  "column": 49
+                }
+              },
+              "declaration": {
+                "type": "NumberTypeAnnotation",
+                "start": 42,
+                "end": 48,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 42
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 48
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/flow/declare-module/11/actual.js
+++ b/test/fixtures/flow/declare-module/11/actual.js
@@ -1,0 +1,1 @@
+declare module A { declare export default { foo(): number; } }

--- a/test/fixtures/flow/declare-module/11/expected.json
+++ b/test/fixtures/flow/declare-module/11/expected.json
@@ -75,7 +75,7 @@
           },
           "body": [
             {
-              "type": "DeclareExportDefault",
+              "type": "DeclareExportDeclaration",
               "start": 19,
               "end": 60,
               "loc": {
@@ -174,7 +174,8 @@
                 ],
                 "indexers": [],
                 "exact": false
-              }
+              },
+              "default": true
             }
           ]
         }

--- a/test/fixtures/flow/declare-module/11/expected.json
+++ b/test/fixtures/flow/declare-module/11/expected.json
@@ -1,0 +1,185 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 62,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 62
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 62,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 62
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "DeclareModule",
+        "start": 0,
+        "end": 62,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 62
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 15,
+          "end": 16,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 15
+            },
+            "end": {
+              "line": 1,
+              "column": 16
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "body": {
+          "type": "BlockStatement",
+          "start": 17,
+          "end": 62,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 17
+            },
+            "end": {
+              "line": 1,
+              "column": 62
+            }
+          },
+          "body": [
+            {
+              "type": "DeclareExportDefault",
+              "start": 19,
+              "end": 60,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 19
+                },
+                "end": {
+                  "line": 1,
+                  "column": 60
+                }
+              },
+              "declaration": {
+                "type": "ObjectTypeAnnotation",
+                "start": 42,
+                "end": 60,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 42
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 60
+                  }
+                },
+                "callProperties": [],
+                "properties": [
+                  {
+                    "type": "ObjectTypeProperty",
+                    "start": 44,
+                    "end": 58,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 44
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 58
+                      }
+                    },
+                    "value": {
+                      "type": "FunctionTypeAnnotation",
+                      "start": 44,
+                      "end": 57,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 44
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 57
+                        }
+                      },
+                      "params": [],
+                      "rest": null,
+                      "typeParameters": null,
+                      "returnType": {
+                        "type": "NumberTypeAnnotation",
+                        "start": 51,
+                        "end": 57,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 51
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 57
+                          }
+                        }
+                      }
+                    },
+                    "static": false,
+                    "key": {
+                      "type": "Identifier",
+                      "start": 44,
+                      "end": 47,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 44
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 47
+                        },
+                        "identifierName": "foo"
+                      },
+                      "name": "foo"
+                    },
+                    "optional": false
+                  }
+                ],
+                "indexers": [],
+                "exact": false
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/flow/declare-module/12/actual.js
+++ b/test/fixtures/flow/declare-module/12/actual.js
@@ -1,0 +1,1 @@
+declare module A { declare export default function method(): number; }

--- a/test/fixtures/flow/declare-module/12/expected.json
+++ b/test/fixtures/flow/declare-module/12/expected.json
@@ -75,7 +75,7 @@
           },
           "body": [
             {
-              "type": "DeclareExportDefault",
+              "type": "DeclareExportDeclaration",
               "start": 19,
               "end": 68,
               "loc": {
@@ -168,7 +168,8 @@
                     "predicate": null
                   }
                 }
-              }
+              },
+              "default": true
             }
           ]
         }

--- a/test/fixtures/flow/declare-module/12/expected.json
+++ b/test/fixtures/flow/declare-module/12/expected.json
@@ -1,0 +1,179 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 70,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 70
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 70,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 70
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "DeclareModule",
+        "start": 0,
+        "end": 70,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 70
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 15,
+          "end": 16,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 15
+            },
+            "end": {
+              "line": 1,
+              "column": 16
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "body": {
+          "type": "BlockStatement",
+          "start": 17,
+          "end": 70,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 17
+            },
+            "end": {
+              "line": 1,
+              "column": 70
+            }
+          },
+          "body": [
+            {
+              "type": "DeclareExportDefault",
+              "start": 19,
+              "end": 68,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 19
+                },
+                "end": {
+                  "line": 1,
+                  "column": 68
+                }
+              },
+              "declaration": {
+                "type": "DeclareFunction",
+                "start": 42,
+                "end": 68,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 42
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 68
+                  }
+                },
+                "id": {
+                  "type": "Identifier",
+                  "start": 51,
+                  "end": 67,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 51
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 67
+                    },
+                    "identifierName": "method"
+                  },
+                  "name": "method",
+                  "typeAnnotation": {
+                    "type": "TypeAnnotation",
+                    "start": 57,
+                    "end": 67,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 57
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 67
+                      }
+                    },
+                    "typeAnnotation": {
+                      "type": "FunctionTypeAnnotation",
+                      "start": 57,
+                      "end": 67,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 57
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 67
+                        }
+                      },
+                      "typeParameters": null,
+                      "params": [],
+                      "rest": null,
+                      "returnType": {
+                        "type": "NumberTypeAnnotation",
+                        "start": 61,
+                        "end": 67,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 61
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 67
+                          }
+                        }
+                      }
+                    },
+                    "predicate": null
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/flow/declare-module/13/actual.js
+++ b/test/fixtures/flow/declare-module/13/actual.js
@@ -1,0 +1,1 @@
+declare module A { declare export var foo: { foo(): number; } }

--- a/test/fixtures/flow/declare-module/13/expected.json
+++ b/test/fixtures/flow/declare-module/13/expected.json
@@ -75,7 +75,7 @@
           },
           "body": [
             {
-              "type": "DeclareExport",
+              "type": "DeclareExportDeclaration",
               "start": 19,
               "end": 61,
               "loc": {
@@ -221,7 +221,8 @@
                     }
                   }
                 }
-              }
+              },
+              "default": false
             }
           ]
         }

--- a/test/fixtures/flow/declare-module/13/expected.json
+++ b/test/fixtures/flow/declare-module/13/expected.json
@@ -1,0 +1,232 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 63,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 63
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 63,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 63
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "DeclareModule",
+        "start": 0,
+        "end": 63,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 63
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 15,
+          "end": 16,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 15
+            },
+            "end": {
+              "line": 1,
+              "column": 16
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "body": {
+          "type": "BlockStatement",
+          "start": 17,
+          "end": 63,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 17
+            },
+            "end": {
+              "line": 1,
+              "column": 63
+            }
+          },
+          "body": [
+            {
+              "type": "DeclareExport",
+              "start": 19,
+              "end": 61,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 19
+                },
+                "end": {
+                  "line": 1,
+                  "column": 61
+                }
+              },
+              "declaration": {
+                "type": "DeclareVariable",
+                "start": 34,
+                "end": 61,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 34
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 61
+                  }
+                },
+                "id": {
+                  "type": "Identifier",
+                  "start": 38,
+                  "end": 61,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 38
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 61
+                    },
+                    "identifierName": "foo"
+                  },
+                  "name": "foo",
+                  "typeAnnotation": {
+                    "type": "TypeAnnotation",
+                    "start": 41,
+                    "end": 61,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 41
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 61
+                      }
+                    },
+                    "typeAnnotation": {
+                      "type": "ObjectTypeAnnotation",
+                      "start": 43,
+                      "end": 61,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 43
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 61
+                        }
+                      },
+                      "callProperties": [],
+                      "properties": [
+                        {
+                          "type": "ObjectTypeProperty",
+                          "start": 45,
+                          "end": 59,
+                          "loc": {
+                            "start": {
+                              "line": 1,
+                              "column": 45
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 59
+                            }
+                          },
+                          "value": {
+                            "type": "FunctionTypeAnnotation",
+                            "start": 45,
+                            "end": 58,
+                            "loc": {
+                              "start": {
+                                "line": 1,
+                                "column": 45
+                              },
+                              "end": {
+                                "line": 1,
+                                "column": 58
+                              }
+                            },
+                            "params": [],
+                            "rest": null,
+                            "typeParameters": null,
+                            "returnType": {
+                              "type": "NumberTypeAnnotation",
+                              "start": 52,
+                              "end": 58,
+                              "loc": {
+                                "start": {
+                                  "line": 1,
+                                  "column": 52
+                                },
+                                "end": {
+                                  "line": 1,
+                                  "column": 58
+                                }
+                              }
+                            }
+                          },
+                          "static": false,
+                          "key": {
+                            "type": "Identifier",
+                            "start": 45,
+                            "end": 48,
+                            "loc": {
+                              "start": {
+                                "line": 1,
+                                "column": 45
+                              },
+                              "end": {
+                                "line": 1,
+                                "column": 48
+                              },
+                              "identifierName": "foo"
+                            },
+                            "name": "foo"
+                          },
+                          "optional": false
+                        }
+                      ],
+                      "indexers": [],
+                      "exact": false
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/flow/declare-module/14/actual.js
+++ b/test/fixtures/flow/declare-module/14/actual.js
@@ -1,0 +1,1 @@
+declare module A { declare export function foo(): number; }

--- a/test/fixtures/flow/declare-module/14/expected.json
+++ b/test/fixtures/flow/declare-module/14/expected.json
@@ -1,0 +1,179 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 59,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 59
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 59,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 59
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "DeclareModule",
+        "start": 0,
+        "end": 59,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 59
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 15,
+          "end": 16,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 15
+            },
+            "end": {
+              "line": 1,
+              "column": 16
+            },
+            "identifierName": "A"
+          },
+          "name": "A"
+        },
+        "body": {
+          "type": "BlockStatement",
+          "start": 17,
+          "end": 59,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 17
+            },
+            "end": {
+              "line": 1,
+              "column": 59
+            }
+          },
+          "body": [
+            {
+              "type": "DeclareExport",
+              "start": 19,
+              "end": 57,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 19
+                },
+                "end": {
+                  "line": 1,
+                  "column": 57
+                }
+              },
+              "declaration": {
+                "type": "DeclareFunction",
+                "start": 34,
+                "end": 57,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 34
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 57
+                  }
+                },
+                "id": {
+                  "type": "Identifier",
+                  "start": 43,
+                  "end": 56,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 43
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 56
+                    },
+                    "identifierName": "foo"
+                  },
+                  "name": "foo",
+                  "typeAnnotation": {
+                    "type": "TypeAnnotation",
+                    "start": 46,
+                    "end": 56,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 46
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 56
+                      }
+                    },
+                    "typeAnnotation": {
+                      "type": "FunctionTypeAnnotation",
+                      "start": 46,
+                      "end": 56,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 46
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 56
+                        }
+                      },
+                      "typeParameters": null,
+                      "params": [],
+                      "rest": null,
+                      "returnType": {
+                        "type": "NumberTypeAnnotation",
+                        "start": 50,
+                        "end": 56,
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 50
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 56
+                          }
+                        }
+                      }
+                    },
+                    "predicate": null
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/flow/declare-module/14/expected.json
+++ b/test/fixtures/flow/declare-module/14/expected.json
@@ -75,7 +75,7 @@
           },
           "body": [
             {
-              "type": "DeclareExport",
+              "type": "DeclareExportDeclaration",
               "start": 19,
               "end": 57,
               "loc": {
@@ -168,7 +168,8 @@
                     "predicate": null
                   }
                 }
-              }
+              },
+              "default": false
             }
           ]
         }

--- a/test/fixtures/flow/declare-module/15/actual.js
+++ b/test/fixtures/flow/declare-module/15/actual.js
@@ -1,0 +1,1 @@
+declare module A { declare export default module B {} }

--- a/test/fixtures/flow/declare-module/15/options.json
+++ b/test/fixtures/flow/declare-module/15/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token (1:42)"
+}

--- a/test/fixtures/flow/declare-module/16/actual.js
+++ b/test/fixtures/flow/declare-module/16/actual.js
@@ -1,0 +1,1 @@
+declare module A { declare export module B {} }

--- a/test/fixtures/flow/declare-module/16/options.json
+++ b/test/fixtures/flow/declare-module/16/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token (1:34)"
+}

--- a/test/fixtures/flow/declare-module/17/actual.js
+++ b/test/fixtures/flow/declare-module/17/actual.js
@@ -1,0 +1,1 @@
+declare module A { declare export export {} }

--- a/test/fixtures/flow/declare-module/17/options.json
+++ b/test/fixtures/flow/declare-module/17/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unexpected token (1:34)"
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | yes
| Deprecations?     | no
| Spec compliancy?  | sorta?
| Tests added/pass? | yes
| Fixed tickets     | N/A
| License           | MIT

Adds support for the following Flow syntaxes:

```js
declare module A { declare export default {}; }
declare module A { declare export default number; }
declare module A { declare export default var val: number; }
declare module A { declare export default function method(): number; }

declare module A { declare export var val: number; }
declare module A { declare export function method(): number; }
```

cc @samwgoldman