### PR TITLE
WIP: typescript plugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,9 +14,11 @@ import "./tokenizer/context";
 import estreePlugin from "./plugins/estree";
 import flowPlugin from "./plugins/flow";
 import jsxPlugin from "./plugins/jsx";
+import typescriptPlugin from "./plugins/typescript";
 plugins.estree = estreePlugin;
 plugins.flow = flowPlugin;
 plugins.jsx = jsxPlugin;
+plugins.typescript = typescriptPlugin;
 
 export function parse(input, options) {
   return new Parser(options, input).parse();

--- a/src/parser/expression.js
+++ b/src/parser/expression.js
@@ -333,7 +333,7 @@ pp.parseSubscript = function (base, startPos, startLoc, noCalls) {
     return [base];
   }
   return [null, base];
-}
+};
 
 pp.parseCallExpressionArguments = function (close, possibleAsyncArrow) {
   const elts = [];

--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -672,6 +672,9 @@ pp.parseClassBody = function (node) {
       decorators = [];
     }
 
+    // hook for typescript parsing
+    this.maybeParseClassElementModifier(method);
+
     method.static = false;
     if (this.match(tt.name) && this.state.value === "static") {
       const key = this.parseIdentifier(true); // eats 'static'
@@ -768,6 +771,11 @@ pp.parseClassBody = function (node) {
 
   this.state.strict = oldStrict;
 };
+
+// Used by typescript to parse public/protected/private
+pp.maybeParseClassElementModifier = function (node) {
+  return node;
+}
 
 pp.parseClassProperty = function (node) {
   const noPluginMsg = "You can only use Class Properties when the 'classProperties' plugin is enabled.";

--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -775,7 +775,7 @@ pp.parseClassBody = function (node) {
 // Used by typescript to parse public/protected/private
 pp.maybeParseClassElementModifier = function (node) {
   return node;
-}
+};
 
 pp.parseClassProperty = function (node) {
   const noPluginMsg = "You can only use Class Properties when the 'classProperties' plugin is enabled.";

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -390,16 +390,35 @@ pp.tsParseType = function() {
   //
   //   PrimaryType:
   //    ParenthesizedType
-  //    PredefinedType
-  //    TypeReference
-  //    ObjectType
-  //    ArrayType
-  //    TupleType
-  //    TypeQuery
+  //    PredefinedType - done
+  //    TypeReference - done
+  //    ObjectType - not done
+  //    ArrayType - done
+  //    TupleType - done
+  //    TypeQuery - done
+  //    ThisType - done
   //
   //   ParenthesizedType:
   //    ( Type )
 }
+
+pp.tsParseTypeAlias = function (node) {
+  node.id = this.tsParseTypeIdentifier();
+
+  if (this.isRelational("<")) {
+    node.typeParameters = this.tsParseTypeParameterList();
+  } else {
+    node.typeParameters = null;
+  }
+
+  // XXX: flow: `.right`, ts compiler: `.typeAnnotation`, though
+  // typeAnnotation seems like technically the wrong phrasing.
+  this.expect(tt.eq);
+  node.typeAnnotation = this.tsParseType();
+  this.semicolon();
+
+  return this.finishNode(node, "TypeAlias");
+};
 
 export default function (instance) {
   instance.extend("parseExpressionStatement", function (inner) {
@@ -408,6 +427,8 @@ export default function (instance) {
         if (this.match(tt.name)) {
           if (expr.name === "interface") {
             return this.tsParseInterface(node);
+          } else if (expr.name === "type") {
+            return this.tsParseTypeAlias(node);
           }
         }
       }

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -5,6 +5,7 @@ import Parser from "../parser";
 // XXX: targeting ts1.8 grammar:
 // https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#A
 // attempt to copy words/identifiers from flow plugin where possible
+// also see https://github.com/babel/babylon/issues/320
 const pp = Parser.prototype;
 
 // pp.tsParseDeclareInterface = function (node) {
@@ -33,7 +34,7 @@ pp.tsParseInterface = function(node) {
   // XXX: handle generics (TypeParameters), i.e. interface<T> A { ... }
   node.typeParameters = null;
   if (this.isRelational("<")) {
-    node.typeParameters = this.tsParseTypeParameterDeclaration();
+    node.typeParameters = this.tsParseTypeParameterList();
   }
 
   // XXX: handle InterfaceExtendsClause
@@ -46,8 +47,9 @@ pp.tsParseInterface = function(node) {
   return this.finishNode(node, "InterfaceDeclaration");
 };
 
-// "TypeParameters" acc. spec
-pp.tsParseTypeParameterDeclaration = function() {
+// via flowParseTypeParameterDeclaration.
+// From the spec: TypeParameters.
+pp.tsParseTypeParameterList = function() {
   // XXX: inType?
   const node = this.startNode();
   node.params = [];
@@ -61,7 +63,7 @@ pp.tsParseTypeParameterDeclaration = function() {
   } while (!this.isRelational(">"));
   this.expectRelational(">");
 
-  return this.finishNode(node, "TypeParameterDeclaration");
+  return this.finishNode(node, "TypeParameterList");
 };
 
 const strictModeReservedWords = [

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -141,8 +141,7 @@ pp.tsParseTypeParameter = function() {
   // and the flow plugin calls just a .typeAnnotation.
   // See: flowParseTypeAnnotatableIdentifier + flowParseTypeParameter
   node.constraint = null;
-  if (this.isContextual("extends")) {
-    this.next();
+  if (this.eat(tt._extends)) {
     node.constraint = this.tsParseType();
   }
 

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -314,6 +314,10 @@ pp.tsParsePrimaryType = function() {
       return this.tsParsePredefinedType(node, identifier) || this.tsParseTypeReference(node, identifier);
     case tt.braceL:
       return this.tsParseObjectType();
+    case tt._this:
+      // XXX: flow ThisTypeAnnotation
+      this.expect(tt._this);
+      return this.finishNode(node, "ThisType");
   }
 };
 

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -306,6 +306,21 @@ pp.tsEatObjectTypeSemicolon = function() {
   }
 };
 
+pp.tsParseTupleType = function(node) {
+  this.expect(tt.bracketL);
+  node.elementTypes = [];
+
+  while (!this.match(tt.bracketR)) {
+    node.elementTypes.push(this.tsParseType());
+    if (!this.match(tt.bracketR)) {
+      this.expect(tt.comma);
+    }
+  }
+  this.expect(tt.bracketR);
+  this.tsEatObjectTypeSemicolon();
+  return this.finishNode(node, "TupleType");
+};
+
 pp.tsParsePrimaryType = function() {
   const node = this.startNode();
   switch (this.state.type) {
@@ -318,6 +333,8 @@ pp.tsParsePrimaryType = function() {
       // XXX: flow ThisTypeAnnotation
       this.expect(tt._this);
       return this.finishNode(node, "ThisType");
+    case tt.bracketL:
+      return this.tsParseTupleType(node);
   }
 };
 

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -852,8 +852,6 @@ export default function (instance) {
       if (this.isContextual("implements")) {
         this.next();
 
-        const heritageNode = this.startNode();
-
         const implemented = node.implements = [];
         do {
           const node = this.startNode();
@@ -877,7 +875,7 @@ export default function (instance) {
         this.next();
         node.modifiers = [this.finishNode(modifier, modifierMap[maybeModifierValue])];
       }
-    }
+    };
   });
 
   instance.extend("parseClassMethod", function(inner) {

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -245,12 +245,23 @@ pp.tsParseObjectType = function() {
   while (!this.match(tt.braceR)) {
     if (this.match(tt.bracketL)) {
       nodeStart.members.push(this.tsParseObjectTypeIndexSignature());
+    } else if (this.match(tt._new)) {
+      nodeStart.members.push(this.tsParseObjectTypeConstructorSignature());
+      break;
     }
   }
   this.expect(tt.braceR);
 
   // XXX: ObjectTypeAnnotation
   return this.finishNode(nodeStart, "TypeLiteral");
+};
+
+pp.tsParseObjectTypeConstructorSignature = function() {
+  const node = this.startNode();
+  this.expect(tt._new);
+
+  // looks like: new <A, B>(A, c): B;
+  return this.finishNode(node, "ConstructSignature");
 };
 
 pp.tsParseObjectTypeIndexSignature = function() {

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -868,4 +868,15 @@ export default function (instance) {
       }
     };
   });
+
+  instance.extend("maybeParseClassElementModifier", function() {
+    return function(node) {
+      const maybeModifierValue = this.state.value;
+      if (this.tsIsModifierKeyword()) {
+        const modifier = this.startNode();
+        this.next();
+        node.modifiers = [this.finishNode(modifier, modifierMap[maybeModifierValue])];
+      }
+    }
+  });
 }

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -277,9 +277,11 @@ pp.tsParseObjectTypeIndexSignature = function() {
 
   // XXX: ts compiler calls this `type`, but
   // babylon uses type to mean the node's type.
-  // `key` is the flow terminology. (this is also
-  // inconsistent with `typeAnnotation` below...)
-  paramNode.key = this.tsParseType();
+  // flow calls this `key` (this is also
+  // inconsistent with `typeAnnotation` below...),
+  // and typescript-eslint-parser converts these into
+  // `typeAnnotation`
+  paramNode.typeAnnotation = this.tsParseType();
   if (["StringKeyword", "NumberKeyword"].indexOf(paramNode.key.type) === -1) {
     this.raise(paramNode.key.start, "Object indexer can only have string or number type");
   }
@@ -291,8 +293,10 @@ pp.tsParseObjectTypeIndexSignature = function() {
   this.expect(tt.colon); // XXX: flow handles this with flowParseTypeInitialiser
 
   // XXX: again, ts calls this `type`, but that overloads the word
-  // in babylon. flow calls this `value`
-  node.value = this.tsParseType();
+  // in babylon. flow calls this `value`.
+  // typescript-eslint-parser converts these into
+  // `typeAnnotation`
+  node.typeAnnotation = this.tsParseType();
 
   this.tsEatObjectTypeSemicolon();
   return this.finishNode(node, "IndexSignature");

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -325,6 +325,15 @@ pp.tsParseTupleType = function(node) {
   return this.finishNode(node, "TupleType");
 };
 
+pp.tsParseTypeQuery = function(node) {
+  this.expect(tt._typeof);
+  // XXX: ts calls this FirstNode? flow calls this QualifiedTypeIdentifier,
+  // see notes on tsParseTypeName.
+  node.exprName = this.tsParseTypeName();
+  // XXX: TypeofTypeAnnotation
+  return this.finishNode(node, "TypeQuery");
+};
+
 pp.tsParsePrimaryType = function() {
   const node = this.startNode();
   switch (this.state.type) {
@@ -337,6 +346,8 @@ pp.tsParsePrimaryType = function() {
       // XXX: flow ThisTypeAnnotation
       this.expect(tt._this);
       return this.finishNode(node, "ThisType");
+    case tt._typeof:
+      return this.tsParseTypeQuery(node);
     case tt.bracketL:
       return this.tsParseTupleType(node);
   }

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -349,4 +349,17 @@ export default function (instance) {
       return inner.call(this, node, expr);
     };
   });
+
+  // parse flow type annotations on variable declarator heads - let foo: string = bar
+  instance.extend("parseVarHead", function (inner) {
+    return function(decl) {
+      inner.call(this, decl);
+      if (this.eat(tt.colon)) {
+        // XXX: ts calls this the `type` on the VariableDeclaration,
+        // but babylon already uses `type` to mean the node type.
+        decl.id.typeAnnotation = this.tsParseType();
+        this.finishNode(decl.id, decl.id.type);
+      }
+    };
+  });
 }

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -879,4 +879,22 @@ export default function (instance) {
       }
     }
   });
+
+  instance.extend("parseClassMethod", function(inner) {
+    return function(classBody, method, ...args) {
+      if (this.isRelational("<")) {
+        method.typeParameters = this.tsParseTypeParameters();
+      }
+
+      inner.call(this, classBody, method, ...args);
+    };
+  });
+
+  // also allow type parameters in front of class methods,
+  // i.e. `class X { length<T>() {} }`
+  instance.extend("isClassMethod", function(inner) {
+    return function() {
+      return this.isRelational("<") || inner.call(this);
+    };
+  });
 }

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -216,6 +216,8 @@ pp.tsParseObjectType = function() {
     } else if (this.match(tt._new)) {
       nodeStart.members.push(this.tsParseObjectTypeConstructSignature());
       break;
+    } else if (this.match(tt.parenL) || this.isRelational("<")) {
+      nodeStart.members.push(this.tsParseObjectTypeCallSignature());
     }
   }
   this.expect(tt.braceR);
@@ -227,6 +229,9 @@ pp.tsParseObjectType = function() {
 // parse ConstructSignature / CallSignature:
 // TypeParameters ( ParameterList ) TypeAnnotation
 // new TypeParameters ( ParameterList ) TypeAnnotation
+// This is similar to tsParseFunctionish, except
+// the type annotation at the end is an optional
+// `: Type` instead of a required `=> Type`
 pp.tsParseObjectTypeFunctionish = function(node) {
   node.typeParameters = null;
   if (this.isRelational("<")) {
@@ -243,6 +248,12 @@ pp.tsParseObjectTypeFunctionish = function(node) {
   }
 
   return node;
+};
+
+pp.tsParseObjectTypeCallSignature = function() {
+  const node = this.startNode();
+  this.tsParseObjectTypeFunctionish(node);
+  return this.finishNode(node, "CallSignature");
 };
 
 pp.tsParseObjectTypeConstructSignature = function() {

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -800,4 +800,14 @@ export default function (instance) {
       return inner.call(this, base, startPos, startLoc, noCalls);
     };
   });
+
+  // Classes
+  instance.extend("parseClassId", function(inner) {
+    return function(node) {
+      inner.apply(this, arguments);
+      if (this.isRelational("<")) {
+        node.typeParameters = this.tsParseTypeParameters();
+      }
+    };
+  });
 }

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -300,11 +300,11 @@ pp.tsParseObjectTypePropertyOrMethodSignature = function() {
 };
 
 // parse ConstructSignature / CallSignature:
-// TypeParameters ( ParameterList ) TypeAnnotation
-// new TypeParameters ( ParameterList ) TypeAnnotation
-// This is similar to tsParseFunctionish, except
-// the type annotation at the end is an optional
-// `: Type` instead of a required `=> Type`
+// TypeParameters (ParameterList) TypeAnnotation
+// new TypeParameters (ParameterList) TypeAnnotation
+// This is similar to tsParseFunctionish, except
+// the type annotation at the end is an optional
+// `: Type` instead of a required `=> Type`
 pp.tsParseObjectTypeFunctionish = function(node) {
   node.typeParameters = null;
   if (this.isRelational("<")) {
@@ -502,7 +502,7 @@ pp.tsParseParameterList = function() {
 };
 
 // parse constructor type / function type signatures:
-// TypeParametersopt (ParameterList) => Type
+// TypeParameters (ParameterList) => Type
 pp.tsParseFunctionish = function(node) {
   node.typeParameters = null;
   if (this.isRelational("<")) {
@@ -578,7 +578,7 @@ pp.tsParseType = function() {
   }
 
   return this.tsParseMaybeUnionType();
-}
+};
 
 pp.tsParseTypeAlias = function (node) {
   node.id = this.tsParseTypeIdentifier();

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -156,6 +156,10 @@ const typeIdentifierReservedWords = [
   "number",
   "string",
   "symbol",
+  // XXX: note that using `void` in e.g. a TypeParameterList
+  // produces a different error in the ts compiler than the above:
+  // interface X<S, void> {}
+  "void",
 ];
 
 pp.tsParseTypeIdentifier = function(liberal) {

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -552,6 +552,7 @@ pp.tsParseType = function() {
     // We attempt to first parse as a function type,
     // and revert back the state if it fails. Later,
     // tsParsePrimaryType will handle the parenthesized
+    // type case.
     const state = this.state.clone();
     try {
       return this.tsParseFunctionType();
@@ -561,32 +562,6 @@ pp.tsParseType = function() {
   }
 
   return this.tsParseMaybeUnionType();
-  // should handle...
-  //   Type:
-  //    UnionOrIntersectionOrPrimaryType
-  //    FunctionType
-  //    ConstructorType
-  //
-  //   UnionOrIntersectionOrPrimaryType:
-  //    UnionType
-  //    IntersectionOrPrimaryType
-  //
-  //   IntersectionOrPrimaryType:
-  //    IntersectionType
-  //    PrimaryType
-  //
-  //   PrimaryType:
-  //    ParenthesizedType - done
-  //    PredefinedType - done
-  //    TypeReference - done
-  //    ObjectType - not done
-  //    ArrayType - done
-  //    TupleType - done
-  //    TypeQuery - done
-  //    ThisType - done
-  //
-  //   ParenthesizedType:
-  //    ( Type )
 }
 
 pp.tsParseTypeAlias = function (node) {
@@ -598,7 +573,7 @@ pp.tsParseTypeAlias = function (node) {
     node.typeParameters = null;
   }
 
-  // XXX: flow: `.right`, ts compiler: `.typeAnnotation`, though
+  // XXX: flow: `.right`, ts compiler: `.type`, though
   // typeAnnotation seems like the wrong phrasing.
   this.expect(tt.eq);
   node.typeAnnotation = this.tsParseType();

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -39,12 +39,84 @@ pp.tsParseInterface = function(node) {
 
   // XXX: handle InterfaceExtendsClause
   node.extends = [];
+  if (this.eat(tt._extends)) {
+    do {
+      node.extends.push(this.tsParseHeritageClause());
+    } while (this.eat(tt.comma));
+  }
 
   // XXX: handle ObjectType
   node.body = null;
   console.log(node);
 
   return this.finishNode(node, "InterfaceDeclaration");
+};
+
+// parses the latter half of `extends Something`.
+// caller must remove `extends` themself.
+// from: flowParseInterfaceExtends
+pp.tsParseHeritageClause = function() {
+  const node = this.startNode();
+  node.id = this.tsParseTypeName();
+
+  // XXX: it seems like flow calls ts.TypeArguments (the <T> part)
+  // flow.TypeParamterInstantiation, which are concrete type refs that
+  // cannot be newly declared generics. Different from ts.TypeParameter.
+
+  // extended type can be generic and have a TypeArguments, i.e. `extends Something<T>`
+  if (this.isRelational("<")) {
+    node.typeArguments = this.tsParseTypeArgumentList();
+  } else {
+    node.typeArguments = null;
+  }
+
+  // XXX: flow calls these InterfaceExtends
+  return this.finishNode(node, "HeritageClause");
+};
+
+// stuff like `X.G` within `var x: X.G<T>`
+// XXX: Flow calls these QualifiedTypeIdentifier;
+// official ts ast calls these PropertyAccessExpression,
+// while the spec grammar calls them TypeName.
+//
+// The ts ast also calls a.s()'s expression a PropertyAccessExpression,
+// maybe we should just call these MemberExpression?
+// typescript-eslint-parser also converts these into MemberExpression.
+//
+// We can't just call pp.parseExprSubscripts because it also attempts to
+// parse things like a[c] which are valid MemberExpression's, but not
+// valid typescript. type names.
+//
+// This is taken from flowParseQualifiedTypeIdentifier.
+pp.tsParseTypeName = function() {
+  let node = this.parseIdentifier();
+
+  while (this.eat(tt.dot)) {
+    const node2 = this.startNode();
+    node2.object = node;
+    node2.property = this.parseIdentifier();
+    node = this.finishNode(node2, "MemberExpression");
+  }
+
+  return node;
+};
+
+// similar to flowParseTypeParameterInstantiation
+pp.tsParseTypeArgumentList = function() {
+  // XXX: inType?
+  const node = this.startNode();
+  node.arguments = [];
+
+  this.expectRelational("<");
+  while (!this.isRelational(">")) {
+    node.arguments.push(this.tsParseType());
+    if (!this.isRelational(">")) {
+      this.expect(tt.comma);
+    }
+  }
+  this.expectRelational(">");
+
+  return this.finishNode(node, "TypeArgumentList");
 };
 
 // via flowParseTypeParameterDeclaration.
@@ -139,6 +211,7 @@ pp.tsParseType = function() {
   //
   //   ParenthesizedType:
   //    ( Type )
+  this.next(); // skip it? this will fail for anything more complex than a name
   return this.finishNode(node, "SomeTypeAnnotation")
 }
 

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -448,12 +448,16 @@ const modifierMap = {
   "protected": "ProtectedKeyword",
 };
 
+pp.tsIsModifierKeyword = function() {
+  return this.match(tt.name) && modifierMap[this.state.value];
+};
+
 pp.tsParseParameter = function() {
   const node = this.startNode();
 
   node.modifiers = null;
   const maybeModifierValue = this.state.value;
-  if (this.match(tt.name) && modifierMap[maybeModifierValue]) {
+  if (this.tsIsModifierKeyword()) {
     const modifier = this.startNode();
     this.next();
     node.modifiers = [this.finishNode(modifier, modifierMap[maybeModifierValue])];
@@ -714,7 +718,7 @@ export default function (instance) {
   instance.extend("parseMaybeDefault", function (inner) {
     return function (...args) {
       const maybeModifierValue = this.state.value;
-      if (this.match(tt.name) && modifierMap[maybeModifierValue] && this.lookahead().type === tt.name) {
+      if (this.tsIsModifierKeyword()) {
         const modifier = this.startNode();
         this.next();
         const modifiers = [this.finishNode(modifier, modifierMap[maybeModifierValue])];

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -34,7 +34,7 @@ pp.tsParseInterface = function(node) {
   // XXX: handle generics (TypeParameters), i.e. interface<T> A { ... }
   node.typeParameters = null;
   if (this.isRelational("<")) {
-    node.typeParameters = this.tsParseTypeParameterList();
+    node.typeParameters = this.tsParseTypeParameters();
   }
 
   // XXX: handle InterfaceExtendsClause
@@ -121,21 +121,20 @@ pp.tsParseTypeArgumentList = function() {
 
 // via flowParseTypeParameterDeclaration.
 // From the spec: TypeParameters.
-pp.tsParseTypeParameterList = function() {
+pp.tsParseTypeParameters = function() {
   // XXX: inType?
-  const node = this.startNode();
-  node.params = [];
+  const parameters = [];
 
   this.expectRelational("<");
   do {
-    node.params.push(this.tsParseTypeParameter());
+    parameters.push(this.tsParseTypeParameter());
     if (!this.isRelational(">")) {
       this.expect(tt.comma);
     }
   } while (!this.isRelational(">"));
   this.expectRelational(">");
 
-  return this.finishNode(node, "TypeParameterList");
+  return parameters;
 };
 
 const strictModeReservedWords = [
@@ -406,7 +405,7 @@ pp.tsParseTypeAlias = function (node) {
   node.id = this.tsParseTypeIdentifier();
 
   if (this.isRelational("<")) {
-    node.typeParameters = this.tsParseTypeParameterList();
+    node.typeParameters = this.tsParseTypeParameters();
   } else {
     node.typeParameters = null;
   }

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -389,10 +389,9 @@ pp.tsParseParameterList = function() {
   return params;
 };
 
-pp.tsParseConstructorType = function() {
-  const node = this.startNode();
-  this.expect(tt._new);
-
+// parse constructor type / function type signatures:
+// TypeParametersopt (ParameterList) => Type
+pp.tsParseFunctionish = function(node) {
   node.typeParameters = null;
   if (this.isRelational("<")) {
     node.typeParameters = this.tsParseTypeParameters();
@@ -405,12 +404,27 @@ pp.tsParseConstructorType = function() {
 
   node.typeAnnotation = this.tsParseType();
 
+  return node;
+};
+
+pp.tsParseConstructorType = function() {
+  const node = this.startNode();
+  this.expect(tt._new);
+  this.tsParseFunctionish(node);
   return this.finishNode(node, "ConstructorType");
+};
+
+pp.tsParseFunctionType = function() {
+  const node = this.startNode();
+  this.tsParseFunctionish(node);
+  return this.finishNode(node, "FunctionType");
 };
 
 pp.tsParseType = function() {
   if (this.match(tt._new)) {
     return this.tsParseConstructorType();
+  } else if (this.match(tt.parenL) || this.isRelational("<")) {
+    return this.tsParseFunctionType();
   }
 
   return this.tsParseMaybeArrayType();

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -338,8 +338,23 @@ pp.tsParsePrimaryType = function() {
   }
 };
 
+pp.tsParseMaybeArrayType = function() {
+  let type = this.tsParsePrimaryType();
+  // while loop, because we could have number[][]
+  while (!this.canInsertSemicolon() && this.match(tt.bracketL)) {
+    // XXX: fix node line start position /location
+    const node = this.startNode();
+    node.elementType = type;
+    this.expect(tt.bracketL);
+    this.expect(tt.bracketR);
+    // XXX: flow ArrayTypeAnnotation
+    type = this.finishNode(node, "ArrayType");
+  }
+  return type;
+};
+
 pp.tsParseType = function() {
-  return this.tsParsePrimaryType();
+  return this.tsParseMaybeArrayType();
   // should handle...
   //   Type:
   //    UnionOrIntersectionOrPrimaryType

--- a/src/plugins/typescript.js
+++ b/src/plugins/typescript.js
@@ -1,0 +1,157 @@
+import { types as tt } from "../tokenizer/types";
+// import { types as ct } from "../tokenizer/context";
+import Parser from "../parser";
+
+// XXX: targeting ts1.8 grammar:
+// https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#A
+// attempt to copy words/identifiers from flow plugin where possible
+const pp = Parser.prototype;
+
+// pp.tsParseDeclareInterface = function (node) {
+//   this.next();
+//   this.flowParseInterfaceish(node);
+//   return this.finishNode(node, "DeclareInterface");
+// };
+//
+
+pp.tsParseInterface = function(node) {
+  //  InterfaceDeclaration:
+  //    interface BindingIdentifier TypeParametersopt InterfaceExtendsClauseopt ObjectType
+  //
+  //   InterfaceExtendsClause:
+  //    extends ClassOrInterfaceTypeList
+  //
+  //   ClassOrInterfaceTypeList:
+  //    ClassOrInterfaceType
+  //    ClassOrInterfaceTypeList , ClassOrInterfaceType
+  //
+  //   ClassOrInterfaceType:
+  //    TypeReference
+
+  node.id = this.parseIdentifier();
+
+  // XXX: handle generics (TypeParameters), i.e. interface<T> A { ... }
+  node.typeParameters = null;
+  if (this.isRelational("<")) {
+    node.typeParameters = this.tsParseTypeParameterDeclaration();
+  }
+
+  // XXX: handle InterfaceExtendsClause
+  node.extends = [];
+
+  // XXX: handle ObjectType
+  node.body = null;
+  console.log(node);
+
+  return this.finishNode(node, "InterfaceDeclaration");
+};
+
+// "TypeParameters" acc. spec
+pp.tsParseTypeParameterDeclaration = function() {
+  // XXX: inType?
+  const node = this.startNode();
+  node.params = [];
+
+  this.expectRelational("<");
+  do {
+    node.params.push(this.tsParseTypeParameter());
+    if (!this.isRelational(">")) {
+      this.expect(tt.comma);
+    }
+  } while (!this.isRelational(">"));
+  this.expectRelational(">");
+
+  return this.finishNode(node, "TypeParameterDeclaration");
+};
+
+const strictModeReservedWords = [
+  "implements",
+  "interface",
+  "let",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "static",
+  "yield",
+];
+
+const typeIdentifierReservedWords = [
+  "any",
+  "boolean",
+  "number",
+  "string",
+  "symbol",
+];
+
+pp.tsParseTypeIdentifier = function(liberal) {
+  if (typeIdentifierReservedWords.indexOf(this.state.value) > -1) {
+    this.raise(this.state.start, `Cannot use ${this.state.value} as a type identifier`);
+  }
+
+  return this.parseIdentifier(liberal);
+};
+
+pp.tsParseTypeParameter = function() {
+  const node = this.startNode();
+  node.name = this.tsParseTypeIdentifier();
+
+  // XXX: flow calls this bounded polymorphism
+  // https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#7
+  // and the flow plugin calls this .typeAnnotation.
+  // See: flowParseTypeAnnotatableIdentifier + flowParseTypeParameter
+  node.constraint = null;
+  if (this.isContextual("extends")) {
+    this.next();
+    node.constraint = this.tsParseType();
+  }
+
+  return this.finishNode(node, "TypeParameter");
+}
+
+pp.tsParseType = function() {
+  const node = this.startNode();
+  // should handle...
+  //     Type:
+  //    UnionOrIntersectionOrPrimaryType
+  //    FunctionType
+  //    ConstructorType
+  //
+  //   UnionOrIntersectionOrPrimaryType:
+  //    UnionType
+  //    IntersectionOrPrimaryType
+  //
+  //   IntersectionOrPrimaryType:
+  //    IntersectionType
+  //    PrimaryType
+  //
+  //   PrimaryType:
+  //    ParenthesizedType
+  //    PredefinedType
+  //    TypeReference
+  //    ObjectType
+  //    ArrayType
+  //    TupleType
+  //    TypeQuery
+  //    ThisType
+  //
+  //   ParenthesizedType:
+  //    ( Type )
+  return this.finishNode(node, "SomeTypeAnnotation")
+}
+
+export default function (instance) {
+  instance.extend("parseExpressionStatement", function (inner) {
+    return function(node, expr) {
+      if (expr.type === "Identifier") {
+        if (this.match(tt.name)) {
+          if (expr.name === "interface") {
+            return this.tsParseInterface(node);
+          }
+        }
+      }
+
+      return inner.call(this, node, expr);
+    };
+  });
+}


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | yes/
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | no
| Fixed tickets     | #320 
| License           | MIT

This is a work in progress that doesn't cover the entire typescript grammar. I'm currently targeting the [typescript 1.8 syntax](https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#A). I've been testing with fixtures locally, but don't have a corpus of test cases checked in yet. In general, this code is pretty rough/prototype stage and there are lots of areas that need cleanup.
 
Some (tentative) design decisions:
- When possible, re-use existing ESTree nodes for the same node
- Otherwise, replicate the official typescript compiler's node
  - Early commits in this PR start off by using making nodes look similar to flow nodes, but I ended up switching away from this as some nodes were hard to adopt because typescript/flow have different syntax or semantics for similar features.
  - Note that the ts compiler uses `.type` in many places for "type annotation" properties, but babel already uses `type` to mean "ast type." In these instances, I've used `.typeAnnotation` in place of `.type`

##### todo
- [ ] add some tests. can we reuse a test suite from somewhere else?
- [ ] decide how the nodes should look/be named
  - maybe follow [typescript-eslint-parser](https://github.com/eslint/typescript-eslint-parser), which prefixes TS-specific nodes with `TS...`
- [ ] complete ts 1.8 grammar parsing
  - [ ] align tsparseproperty name with parsepropertyname?
  - [ ] arrow functions (in particular, `var x = <T>(x:T): T => {};`)
  - [ ] type annotations on classes
  - [ ] ambients
  - [ ] export/import
  - [ ] jsx
- [ ] column locations appear to be off by one?