### PR TITLE
Support sourceType: "unambiguous" parsing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,27 @@ plugins.jsx = jsxPlugin;
 plugins.typescript = typescriptPlugin;
 
 export function parse(input: string, options?: Options): File {
-  return getParser(options, input).parse();
+  if (options && options.sourceType === "unambiguous") {
+    options = Object.assign({}, options);
+    try {
+      options.sourceType = "module";
+      const ast = getParser(options, input).parse();
+
+      // Rather than try to parse as a script first, we opt to parse as a module and convert back
+      // to a script where possible to avoid having to do a full re-parse of the input content.
+      if (!hasModuleSyntax(ast)) ast.program.sourceType = "script";
+      return ast;
+    } catch (moduleError) {
+      try {
+        options.sourceType = "script";
+        return getParser(options, input).parse();
+      } catch (scriptError) {}
+
+      throw moduleError;
+    }
+  } else {
+    return getParser(options, input).parse();
+  }
 }
 
 export function parseExpression(input: string, options?: Options): Expression {
@@ -90,4 +110,17 @@ function getParserClass(
     parserClassCache[key] = cls;
   }
   return cls;
+}
+
+function hasModuleSyntax(ast) {
+  return ast.program.body.some(
+    child =>
+      (child.type === "ImportDeclaration" &&
+        (!child.importKind || child.importKind === "value")) ||
+      (child.type === "ExportNamedDeclaration" &&
+        (!child.exportKind || child.exportKind === "value")) ||
+      (child.type === "ExportAllDeclaration" &&
+        (!child.exportKind || child.exportKind === "value")) ||
+      child.type === "ExportDefaultDeclaration",
+  );
 }

--- a/test/fixtures/core/sourcetype-unambiguous/commonjs/actual.js
+++ b/test/fixtures/core/sourcetype-unambiguous/commonjs/actual.js
@@ -1,0 +1,1 @@
+var foo = require("foo");

--- a/test/fixtures/core/sourcetype-unambiguous/commonjs/expected.json
+++ b/test/fixtures/core/sourcetype-unambiguous/commonjs/expected.json
@@ -1,0 +1,138 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 25,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 25
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 25,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 25
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 25,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 25
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 4,
+            "end": 24,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 4
+              },
+              "end": {
+                "line": 1,
+                "column": 24
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 4,
+              "end": 7,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 4
+                },
+                "end": {
+                  "line": 1,
+                  "column": 7
+                },
+                "identifierName": "foo"
+              },
+              "name": "foo"
+            },
+            "init": {
+              "type": "CallExpression",
+              "start": 10,
+              "end": 24,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 10
+                },
+                "end": {
+                  "line": 1,
+                  "column": 24
+                }
+              },
+              "callee": {
+                "type": "Identifier",
+                "start": 10,
+                "end": 17,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 17
+                  },
+                  "identifierName": "require"
+                },
+                "name": "require"
+              },
+              "arguments": [
+                {
+                  "type": "StringLiteral",
+                  "start": 18,
+                  "end": 23,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 18
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 23
+                    }
+                  },
+                  "extra": {
+                    "rawValue": "foo",
+                    "raw": "\"foo\""
+                  },
+                  "value": "foo"
+                }
+              ]
+            }
+          }
+        ],
+        "kind": "var"
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/core/sourcetype-unambiguous/commonjs/options.json
+++ b/test/fixtures/core/sourcetype-unambiguous/commonjs/options.json
@@ -1,0 +1,3 @@
+{
+  "sourceType": "unambiguous"
+}

--- a/test/fixtures/core/sourcetype-unambiguous/flow/actual.js
+++ b/test/fixtures/core/sourcetype-unambiguous/flow/actual.js
@@ -1,0 +1,3 @@
+import type { Foo } from "bar";
+export type { Foo };
+export type * from "bar";

--- a/test/fixtures/core/sourcetype-unambiguous/flow/expected.json
+++ b/test/fixtures/core/sourcetype-unambiguous/flow/expected.json
@@ -1,0 +1,227 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 78,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 25
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 78,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 25
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start": 0,
+        "end": 31,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 31
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ImportSpecifier",
+            "start": 14,
+            "end": 17,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 14
+              },
+              "end": {
+                "line": 1,
+                "column": 17
+              }
+            },
+            "imported": {
+              "type": "Identifier",
+              "start": 14,
+              "end": 17,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 14
+                },
+                "end": {
+                  "line": 1,
+                  "column": 17
+                },
+                "identifierName": "Foo"
+              },
+              "name": "Foo"
+            },
+            "importKind": null,
+            "local": {
+              "type": "Identifier",
+              "start": 14,
+              "end": 17,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 14
+                },
+                "end": {
+                  "line": 1,
+                  "column": 17
+                },
+                "identifierName": "Foo"
+              },
+              "name": "Foo"
+            }
+          }
+        ],
+        "importKind": "type",
+        "source": {
+          "type": "StringLiteral",
+          "start": 25,
+          "end": 30,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 25
+            },
+            "end": {
+              "line": 1,
+              "column": 30
+            }
+          },
+          "extra": {
+            "rawValue": "bar",
+            "raw": "\"bar\""
+          },
+          "value": "bar"
+        }
+      },
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 32,
+        "end": 52,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 20
+          }
+        },
+        "specifiers": [
+          {
+            "type": "ExportSpecifier",
+            "start": 46,
+            "end": 49,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 14
+              },
+              "end": {
+                "line": 2,
+                "column": 17
+              }
+            },
+            "local": {
+              "type": "Identifier",
+              "start": 46,
+              "end": 49,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 14
+                },
+                "end": {
+                  "line": 2,
+                  "column": 17
+                },
+                "identifierName": "Foo"
+              },
+              "name": "Foo"
+            },
+            "exported": {
+              "type": "Identifier",
+              "start": 46,
+              "end": 49,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 14
+                },
+                "end": {
+                  "line": 2,
+                  "column": 17
+                },
+                "identifierName": "Foo"
+              },
+              "name": "Foo"
+            }
+          }
+        ],
+        "source": null,
+        "exportKind": "type",
+        "declaration": null
+      },
+      {
+        "type": "ExportAllDeclaration",
+        "start": 53,
+        "end": 78,
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 25
+          }
+        },
+        "exportKind": "type",
+        "source": {
+          "type": "StringLiteral",
+          "start": 72,
+          "end": 77,
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 19
+            },
+            "end": {
+              "line": 3,
+              "column": 24
+            }
+          },
+          "extra": {
+            "rawValue": "bar",
+            "raw": "\"bar\""
+          },
+          "value": "bar"
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/core/sourcetype-unambiguous/flow/options.json
+++ b/test/fixtures/core/sourcetype-unambiguous/flow/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "unambiguous",
+  "plugins": ["flow"]
+}

--- a/test/fixtures/core/sourcetype-unambiguous/module-export-all/actual.js
+++ b/test/fixtures/core/sourcetype-unambiguous/module-export-all/actual.js
@@ -1,0 +1,1 @@
+export * from "foo";

--- a/test/fixtures/core/sourcetype-unambiguous/module-export-all/expected.json
+++ b/test/fixtures/core/sourcetype-unambiguous/module-export-all/expected.json
@@ -1,0 +1,69 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 20,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 20
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 20,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 20
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ExportAllDeclaration",
+        "start": 0,
+        "end": 20,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 20
+          }
+        },
+        "source": {
+          "type": "StringLiteral",
+          "start": 14,
+          "end": 19,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 14
+            },
+            "end": {
+              "line": 1,
+              "column": 19
+            }
+          },
+          "extra": {
+            "rawValue": "foo",
+            "raw": "\"foo\""
+          },
+          "value": "foo"
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/core/sourcetype-unambiguous/module-export-all/options.json
+++ b/test/fixtures/core/sourcetype-unambiguous/module-export-all/options.json
@@ -1,0 +1,3 @@
+{
+  "sourceType": "unambiguous"
+}

--- a/test/fixtures/core/sourcetype-unambiguous/module-export-default/actual.js
+++ b/test/fixtures/core/sourcetype-unambiguous/module-export-default/actual.js
@@ -1,0 +1,1 @@
+export default {};

--- a/test/fixtures/core/sourcetype-unambiguous/module-export-default/expected.json
+++ b/test/fixtures/core/sourcetype-unambiguous/module-export-default/expected.json
@@ -1,0 +1,65 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 18,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 18
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 18,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 18
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ExportDefaultDeclaration",
+        "start": 0,
+        "end": 18,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 18
+          }
+        },
+        "declaration": {
+          "type": "ObjectExpression",
+          "start": 15,
+          "end": 17,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 15
+            },
+            "end": {
+              "line": 1,
+              "column": 17
+            }
+          },
+          "properties": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/core/sourcetype-unambiguous/module-export-default/options.json
+++ b/test/fixtures/core/sourcetype-unambiguous/module-export-default/options.json
@@ -1,0 +1,3 @@
+{
+  "sourceType": "unambiguous"
+}

--- a/test/fixtures/core/sourcetype-unambiguous/module-export-named/actual.js
+++ b/test/fixtures/core/sourcetype-unambiguous/module-export-named/actual.js
@@ -1,0 +1,1 @@
+export function fn(){}

--- a/test/fixtures/core/sourcetype-unambiguous/module-export-named/expected.json
+++ b/test/fixtures/core/sourcetype-unambiguous/module-export-named/expected.json
@@ -1,0 +1,104 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 22,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 22
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 22,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 22
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ExportNamedDeclaration",
+        "start": 0,
+        "end": 22,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 22
+          }
+        },
+        "specifiers": [],
+        "source": null,
+        "declaration": {
+          "type": "FunctionDeclaration",
+          "start": 7,
+          "end": 22,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 1,
+              "column": 22
+            }
+          },
+          "id": {
+            "type": "Identifier",
+            "start": 16,
+            "end": 18,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 16
+              },
+              "end": {
+                "line": 1,
+                "column": 18
+              },
+              "identifierName": "fn"
+            },
+            "name": "fn"
+          },
+          "generator": false,
+          "expression": false,
+          "async": false,
+          "params": [],
+          "body": {
+            "type": "BlockStatement",
+            "start": 20,
+            "end": 22,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 20
+              },
+              "end": {
+                "line": 1,
+                "column": 22
+              }
+            },
+            "body": [],
+            "directives": []
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/core/sourcetype-unambiguous/module-export-named/options.json
+++ b/test/fixtures/core/sourcetype-unambiguous/module-export-named/options.json
@@ -1,0 +1,3 @@
+{
+  "sourceType": "unambiguous"
+}

--- a/test/fixtures/core/sourcetype-unambiguous/module-import/actual.js
+++ b/test/fixtures/core/sourcetype-unambiguous/module-import/actual.js
@@ -1,0 +1,1 @@
+import "foo";

--- a/test/fixtures/core/sourcetype-unambiguous/module-import/expected.json
+++ b/test/fixtures/core/sourcetype-unambiguous/module-import/expected.json
@@ -1,0 +1,70 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 13,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 13
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 13,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 13
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start": 0,
+        "end": 13,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 13
+          }
+        },
+        "specifiers": [],
+        "source": {
+          "type": "StringLiteral",
+          "start": 7,
+          "end": 12,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 7
+            },
+            "end": {
+              "line": 1,
+              "column": 12
+            }
+          },
+          "extra": {
+            "rawValue": "foo",
+            "raw": "\"foo\""
+          },
+          "value": "foo"
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/core/sourcetype-unambiguous/module-import/options.json
+++ b/test/fixtures/core/sourcetype-unambiguous/module-import/options.json
@@ -1,0 +1,3 @@
+{
+  "sourceType": "unambiguous"
+}


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | N
| Breaking change?  | N
| New feature?      | Y
| Deprecations?     | 
| Spec compliancy?  | 
| Tests added/pass? | N
| Fixed tickets     | #440
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->

This code is ugly so definitely consider a WIP, but I'm posting for feedback before I go any further. This is the same logic used by Webpack to parse files and will result in files being treated as modules if they contain at least one import/export statement.

My proposed usage of this in Babel itself would be to change Babel's current default `sourceType: "module"` to `sourceType: path.extname(opts.filename || "") === ".mjs" ? "module" : "script"` so that files that Babel can begin toggling module transpilation directly based on `sourceType`, and can throw errors if import statements are inserted into a CommonJS module for instance. Similarly, this means we can stop adding `use strict` at the top of CommonJS files automatically and stop rewriting `this` to `undefined`.

With this, users can opt into `sourceType: unambiguous` in their `.babelrc` to tell Babel to essentially guess what type of file it is. This same logic is already implemented in Webpack and a new other loaders.