### PR TITLE
Ensure locations in ObjectTypeAnnotations do not include semi or comma

### DIFF
--- a/src/plugins/flow.js
+++ b/src/plugins/flow.js
@@ -352,11 +352,7 @@ pp.flowParseObjectTypeIndexer = function (node, isStatic, variance) {
   node.value = this.flowParseTypeInitialiser();
   node.variance = variance;
 
-  // Finish node first to not include a possible semicolon in the locations
-  const indexer = this.finishNode(node, "ObjectTypeIndexer");
-  this.flowObjectTypeSemicolon();
-
-  return indexer;
+  return this.finishNode(node, "ObjectTypeIndexer");
 };
 
 pp.flowParseObjectTypeMethodish = function (node) {
@@ -391,7 +387,6 @@ pp.flowParseObjectTypeMethod = function (startPos, startLoc, isStatic, key) {
   node.static = isStatic;
   node.key = key;
   node.optional = false;
-  this.flowObjectTypeSemicolon();
   return this.finishNode(node, "ObjectTypeProperty");
 };
 
@@ -399,7 +394,6 @@ pp.flowParseObjectTypeCallProperty = function (node, isStatic) {
   const valueNode = this.startNode();
   node.static = isStatic;
   node.value = this.flowParseObjectTypeMethodish(valueNode);
-  this.flowObjectTypeSemicolon();
   return this.finishNode(node, "ObjectTypeCallProperty");
 };
 
@@ -462,7 +456,6 @@ pp.flowParseObjectType = function (allowStatic, allowExact, allowSpread) {
         }
         this.expect(tt.ellipsis);
         node.argument = this.flowParseType();
-        this.flowObjectTypeSemicolon();
         nodeStart.properties.push(this.finishNode(node, "ObjectTypeSpreadProperty"));
       } else {
         propertyKey = this.flowParseObjectPropertyKey();
@@ -481,11 +474,12 @@ pp.flowParseObjectType = function (allowStatic, allowExact, allowSpread) {
           node.optional = optional;
           node.static = isStatic;
           node.variance = variance;
-          this.flowObjectTypeSemicolon();
           nodeStart.properties.push(this.finishNode(node, "ObjectTypeProperty"));
         }
       }
     }
+
+    this.flowObjectTypeSemicolon();
 
     isStatic = false;
   }

--- a/test/fixtures/flow/call-properties/2/expected.json
+++ b/test/fixtures/flow/call-properties/2/expected.json
@@ -105,7 +105,7 @@
                     {
                       "type": "ObjectTypeCallProperty",
                       "start": 10,
-                      "end": 21,
+                      "end": 20,
                       "loc": {
                         "start": {
                           "line": 1,
@@ -113,7 +113,7 @@
                         },
                         "end": {
                           "line": 1,
-                          "column": 21
+                          "column": 20
                         }
                       },
                       "static": false,

--- a/test/fixtures/flow/call-properties/3/expected.json
+++ b/test/fixtures/flow/call-properties/3/expected.json
@@ -105,7 +105,7 @@
                     {
                       "type": "ObjectTypeCallProperty",
                       "start": 10,
-                      "end": 21,
+                      "end": 20,
                       "loc": {
                         "start": {
                           "line": 1,
@@ -113,7 +113,7 @@
                         },
                         "end": {
                           "line": 1,
-                          "column": 21
+                          "column": 20
                         }
                       },
                       "static": false,
@@ -254,7 +254,7 @@
                     {
                       "type": "ObjectTypeProperty",
                       "start": 22,
-                      "end": 32,
+                      "end": 31,
                       "loc": {
                         "start": {
                           "line": 1,
@@ -262,7 +262,7 @@
                         },
                         "end": {
                           "line": 1,
-                          "column": 32
+                          "column": 31
                         }
                       },
                       "key": {

--- a/test/fixtures/flow/call-properties/4/expected.json
+++ b/test/fixtures/flow/call-properties/4/expected.json
@@ -105,7 +105,7 @@
                     {
                       "type": "ObjectTypeCallProperty",
                       "start": 10,
-                      "end": 28,
+                      "end": 27,
                       "loc": {
                         "start": {
                           "line": 1,
@@ -113,7 +113,7 @@
                         },
                         "end": {
                           "line": 1,
-                          "column": 28
+                          "column": 27
                         }
                       },
                       "static": false,

--- a/test/fixtures/flow/call-properties/5/expected.json
+++ b/test/fixtures/flow/call-properties/5/expected.json
@@ -80,7 +80,7 @@
             {
               "type": "ObjectTypeCallProperty",
               "start": 14,
-              "end": 25,
+              "end": 24,
               "loc": {
                 "start": {
                   "line": 1,
@@ -88,7 +88,7 @@
                 },
                 "end": {
                   "line": 1,
-                  "column": 25
+                  "column": 24
                 }
               },
               "static": false,

--- a/test/fixtures/flow/class-properties/named-static/expected.json
+++ b/test/fixtures/flow/class-properties/named-static/expected.json
@@ -81,7 +81,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 20,
-              "end": 30,
+              "end": 29,
               "loc": {
                 "start": {
                   "line": 2,
@@ -89,7 +89,7 @@
                 },
                 "end": {
                   "line": 2,
-                  "column": 12
+                  "column": 11
                 }
               },
               "key": {

--- a/test/fixtures/flow/declare-module/5/expected.json
+++ b/test/fixtures/flow/declare-module/5/expected.json
@@ -127,7 +127,7 @@
                   {
                     "type": "ObjectTypeProperty",
                     "start": 37,
-                    "end": 51,
+                    "end": 50,
                     "loc": {
                       "start": {
                         "line": 1,
@@ -135,7 +135,7 @@
                       },
                       "end": {
                         "line": 1,
-                        "column": 51
+                        "column": 50
                       }
                     },
                     "value": {

--- a/test/fixtures/flow/declare-module/6/expected.json
+++ b/test/fixtures/flow/declare-module/6/expected.json
@@ -121,7 +121,7 @@
                     {
                       "type": "ObjectTypeProperty",
                       "start": 45,
-                      "end": 59,
+                      "end": 58,
                       "loc": {
                         "start": {
                           "line": 1,
@@ -129,7 +129,7 @@
                         },
                         "end": {
                           "line": 1,
-                          "column": 59
+                          "column": 58
                         }
                       },
                       "value": {

--- a/test/fixtures/flow/declare-statements/10/expected.json
+++ b/test/fixtures/flow/declare-statements/10/expected.json
@@ -81,7 +81,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 18,
-              "end": 39,
+              "end": 38,
               "loc": {
                 "start": {
                   "line": 1,
@@ -89,7 +89,7 @@
                 },
                 "end": {
                   "line": 1,
-                  "column": 39
+                  "column": 38
                 }
               },
               "value": {

--- a/test/fixtures/flow/declare-statements/17/expected.json
+++ b/test/fixtures/flow/declare-statements/17/expected.json
@@ -81,7 +81,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 19,
-              "end": 29,
+              "end": 28,
               "loc": {
                 "start": {
                   "line": 2,
@@ -89,7 +89,7 @@
                 },
                 "end": {
                   "line": 2,
-                  "column": 11
+                  "column": 10
                 }
               },
               "key": {
@@ -131,7 +131,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 31,
-              "end": 48,
+              "end": 47,
               "loc": {
                 "start": {
                   "line": 3,
@@ -139,7 +139,7 @@
                 },
                 "end": {
                   "line": 3,
-                  "column": 18
+                  "column": 17
                 }
               },
               "key": {
@@ -181,7 +181,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 50,
-              "end": 60,
+              "end": 59,
               "loc": {
                 "start": {
                   "line": 4,
@@ -189,7 +189,7 @@
                 },
                 "end": {
                   "line": 4,
-                  "column": 11
+                  "column": 10
                 }
               },
               "key": {

--- a/test/fixtures/flow/declare-statements/7/expected.json
+++ b/test/fixtures/flow/declare-statements/7/expected.json
@@ -81,7 +81,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 29,
-              "end": 72,
+              "end": 71,
               "loc": {
                 "start": {
                   "line": 1,
@@ -89,7 +89,7 @@
                 },
                 "end": {
                   "line": 1,
-                  "column": 72
+                  "column": 71
                 }
               },
               "value": {

--- a/test/fixtures/flow/interfaces-module-and-script/10/expected.json
+++ b/test/fixtures/flow/interfaces-module-and-script/10/expected.json
@@ -80,7 +80,7 @@
             {
               "type": "ObjectTypeCallProperty",
               "start": 33,
-              "end": 49,
+              "end": 48,
               "loc": {
                 "start": {
                   "line": 3,
@@ -88,7 +88,7 @@
                 },
                 "end": {
                   "line": 3,
-                  "column": 18
+                  "column": 17
                 }
               },
               "static": true,
@@ -131,7 +131,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 19,
-              "end": 30,
+              "end": 29,
               "loc": {
                 "start": {
                   "line": 2,
@@ -139,7 +139,7 @@
                 },
                 "end": {
                   "line": 2,
-                  "column": 13
+                  "column": 12
                 }
               },
               "key": {
@@ -181,7 +181,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 52,
-              "end": 70,
+              "end": 69,
               "loc": {
                 "start": {
                   "line": 4,
@@ -189,7 +189,7 @@
                 },
                 "end": {
                   "line": 4,
-                  "column": 20
+                  "column": 19
                 }
               },
               "key": {

--- a/test/fixtures/flow/interfaces-module-and-script/4/expected.json
+++ b/test/fixtures/flow/interfaces-module-and-script/4/expected.json
@@ -81,7 +81,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 14,
-              "end": 32,
+              "end": 31,
               "loc": {
                 "start": {
                   "line": 1,
@@ -89,7 +89,7 @@
                 },
                 "end": {
                   "line": 1,
-                  "column": 32
+                  "column": 31
                 }
               },
               "key": {

--- a/test/fixtures/flow/interfaces-module-and-script/5/expected.json
+++ b/test/fixtures/flow/interfaces-module-and-script/5/expected.json
@@ -81,7 +81,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 48,
-              "end": 63,
+              "end": 62,
               "loc": {
                 "start": {
                   "line": 1,
@@ -89,7 +89,7 @@
                 },
                 "end": {
                   "line": 1,
-                  "column": 63
+                  "column": 62
                 }
               },
               "key": {

--- a/test/fixtures/flow/type-annotations/108/expected.json
+++ b/test/fixtures/flow/type-annotations/108/expected.json
@@ -106,7 +106,7 @@
                     {
                       "type": "ObjectTypeProperty",
                       "start": 11,
-                      "end": 21,
+                      "end": 20,
                       "loc": {
                         "start": {
                           "line": 1,
@@ -114,7 +114,7 @@
                         },
                         "end": {
                           "line": 1,
-                          "column": 21
+                          "column": 20
                         }
                       },
                       "key": {
@@ -418,7 +418,7 @@
                     {
                       "type": "ObjectTypeProperty",
                       "start": 68,
-                      "end": 78,
+                      "end": 77,
                       "loc": {
                         "start": {
                           "line": 2,
@@ -426,7 +426,7 @@
                         },
                         "end": {
                           "line": 2,
-                          "column": 21
+                          "column": 20
                         }
                       },
                       "key": {
@@ -468,7 +468,7 @@
                     {
                       "type": "ObjectTypeProperty",
                       "start": 79,
-                      "end": 89,
+                      "end": 88,
                       "loc": {
                         "start": {
                           "line": 2,
@@ -476,7 +476,7 @@
                         },
                         "end": {
                           "line": 2,
-                          "column": 32
+                          "column": 31
                         }
                       },
                       "key": {
@@ -830,7 +830,7 @@
                     {
                       "type": "ObjectTypeProperty",
                       "start": 145,
-                      "end": 175,
+                      "end": 174,
                       "loc": {
                         "start": {
                           "line": 4,
@@ -838,7 +838,7 @@
                         },
                         "end": {
                           "line": 4,
-                          "column": 40
+                          "column": 39
                         }
                       },
                       "key": {
@@ -877,7 +877,7 @@
                           {
                             "type": "ObjectTypeProperty",
                             "start": 151,
-                            "end": 161,
+                            "end": 160,
                             "loc": {
                               "start": {
                                 "line": 4,
@@ -885,7 +885,7 @@
                               },
                               "end": {
                                 "line": 4,
-                                "column": 26
+                                "column": 25
                               }
                             },
                             "key": {
@@ -1350,7 +1350,7 @@
                     {
                       "type": "ObjectTypeProperty",
                       "start": 239,
-                      "end": 267,
+                      "end": 266,
                       "loc": {
                         "start": {
                           "line": 5,
@@ -1358,7 +1358,7 @@
                         },
                         "end": {
                           "line": 5,
-                          "column": 39
+                          "column": 38
                         }
                       },
                       "key": {
@@ -1397,7 +1397,7 @@
                           {
                             "type": "ObjectTypeProperty",
                             "start": 244,
-                            "end": 254,
+                            "end": 253,
                             "loc": {
                               "start": {
                                 "line": 5,
@@ -1405,7 +1405,7 @@
                               },
                               "end": {
                                 "line": 5,
-                                "column": 26
+                                "column": 25
                               }
                             },
                             "key": {

--- a/test/fixtures/flow/type-annotations/135/expected.json
+++ b/test/fixtures/flow/type-annotations/135/expected.json
@@ -79,7 +79,7 @@
             {
               "type": "ObjectTypeSpreadProperty",
               "start": 12,
-              "end": 19,
+              "end": 18,
               "loc": {
                 "start": {
                   "line": 2,
@@ -87,7 +87,7 @@
                 },
                 "end": {
                   "line": 2,
-                  "column": 8
+                  "column": 7
                 }
               },
               "argument": {

--- a/test/fixtures/flow/type-annotations/136/expected.json
+++ b/test/fixtures/flow/type-annotations/136/expected.json
@@ -79,7 +79,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 12,
-              "end": 18,
+              "end": 17,
               "loc": {
                 "start": {
                   "line": 2,
@@ -87,7 +87,7 @@
                 },
                 "end": {
                   "line": 2,
-                  "column": 7
+                  "column": 6
                 }
               },
               "key": {
@@ -133,7 +133,7 @@
             {
               "type": "ObjectTypeSpreadProperty",
               "start": 20,
-              "end": 26,
+              "end": 25,
               "loc": {
                 "start": {
                   "line": 3,
@@ -141,7 +141,7 @@
                 },
                 "end": {
                   "line": 3,
-                  "column": 7
+                  "column": 6
                 }
               },
               "argument": {

--- a/test/fixtures/flow/type-annotations/33/expected.json
+++ b/test/fixtures/flow/type-annotations/33/expected.json
@@ -106,7 +106,7 @@
                     {
                       "type": "ObjectTypeProperty",
                       "start": 8,
-                      "end": 23,
+                      "end": 22,
                       "loc": {
                         "start": {
                           "line": 1,
@@ -114,7 +114,7 @@
                         },
                         "end": {
                           "line": 1,
-                          "column": 23
+                          "column": 22
                         }
                       },
                       "key": {

--- a/test/fixtures/flow/type-annotations/34/expected.json
+++ b/test/fixtures/flow/type-annotations/34/expected.json
@@ -106,7 +106,7 @@
                     {
                       "type": "ObjectTypeProperty",
                       "start": 8,
-                      "end": 23,
+                      "end": 22,
                       "loc": {
                         "start": {
                           "line": 1,
@@ -114,7 +114,7 @@
                         },
                         "end": {
                           "line": 1,
-                          "column": 23
+                          "column": 22
                         }
                       },
                       "key": {

--- a/test/fixtures/flow/type-annotations/36/expected.json
+++ b/test/fixtures/flow/type-annotations/36/expected.json
@@ -106,7 +106,7 @@
                     {
                       "type": "ObjectTypeProperty",
                       "start": 8,
-                      "end": 23,
+                      "end": 22,
                       "loc": {
                         "start": {
                           "line": 1,
@@ -114,7 +114,7 @@
                         },
                         "end": {
                           "line": 1,
-                          "column": 23
+                          "column": 22
                         }
                       },
                       "key": {

--- a/test/fixtures/flow/type-annotations/39/expected.json
+++ b/test/fixtures/flow/type-annotations/39/expected.json
@@ -106,7 +106,7 @@
                     {
                       "type": "ObjectTypeProperty",
                       "start": 8,
-                      "end": 23,
+                      "end": 22,
                       "loc": {
                         "start": {
                           "line": 1,
@@ -114,7 +114,7 @@
                         },
                         "end": {
                           "line": 1,
-                          "column": 23
+                          "column": 22
                         }
                       },
                       "key": {

--- a/test/fixtures/flow/type-annotations/40/expected.json
+++ b/test/fixtures/flow/type-annotations/40/expected.json
@@ -106,7 +106,7 @@
                     {
                       "type": "ObjectTypeProperty",
                       "start": 8,
-                      "end": 23,
+                      "end": 22,
                       "loc": {
                         "start": {
                           "line": 1,
@@ -114,7 +114,7 @@
                         },
                         "end": {
                           "line": 1,
-                          "column": 23
+                          "column": 22
                         }
                       },
                       "key": {

--- a/test/fixtures/flow/type-annotations/43/expected.json
+++ b/test/fixtures/flow/type-annotations/43/expected.json
@@ -106,7 +106,7 @@
                     {
                       "type": "ObjectTypeProperty",
                       "start": 9,
-                      "end": 24,
+                      "end": 23,
                       "loc": {
                         "start": {
                           "line": 1,
@@ -114,7 +114,7 @@
                         },
                         "end": {
                           "line": 1,
-                          "column": 24
+                          "column": 23
                         }
                       },
                       "value": {

--- a/test/fixtures/flow/type-annotations/60/expected.json
+++ b/test/fixtures/flow/type-annotations/60/expected.json
@@ -161,7 +161,7 @@
                     {
                       "type": "ObjectTypeProperty",
                       "start": 10,
-                      "end": 20,
+                      "end": 19,
                       "loc": {
                         "start": {
                           "line": 1,
@@ -169,7 +169,7 @@
                         },
                         "end": {
                           "line": 1,
-                          "column": 20
+                          "column": 19
                         }
                       },
                       "key": {

--- a/test/fixtures/flow/type-annotations/63/expected.json
+++ b/test/fixtures/flow/type-annotations/63/expected.json
@@ -167,7 +167,7 @@
                   {
                     "type": "ObjectTypeProperty",
                     "start": 20,
-                    "end": 30,
+                    "end": 29,
                     "loc": {
                       "start": {
                         "line": 1,
@@ -175,7 +175,7 @@
                       },
                       "end": {
                         "line": 1,
-                        "column": 30
+                        "column": 29
                       }
                     },
                     "key": {

--- a/test/fixtures/flow/type-annotations/98/expected.json
+++ b/test/fixtures/flow/type-annotations/98/expected.json
@@ -106,7 +106,7 @@
                     {
                       "type": "ObjectTypeProperty",
                       "start": 8,
-                      "end": 24,
+                      "end": 23,
                       "loc": {
                         "start": {
                           "line": 1,
@@ -114,7 +114,7 @@
                         },
                         "end": {
                           "line": 1,
-                          "column": 24
+                          "column": 23
                         }
                       },
                       "key": {
@@ -156,7 +156,7 @@
                     {
                       "type": "ObjectTypeProperty",
                       "start": 25,
-                      "end": 40,
+                      "end": 39,
                       "loc": {
                         "start": {
                           "line": 1,
@@ -164,7 +164,7 @@
                         },
                         "end": {
                           "line": 1,
-                          "column": 40
+                          "column": 39
                         }
                       },
                       "key": {
@@ -206,7 +206,7 @@
                     {
                       "type": "ObjectTypeProperty",
                       "start": 41,
-                      "end": 56,
+                      "end": 55,
                       "loc": {
                         "start": {
                           "line": 1,
@@ -214,7 +214,7 @@
                         },
                         "end": {
                           "line": 1,
-                          "column": 56
+                          "column": 55
                         }
                       },
                       "key": {

--- a/test/fixtures/flow/type-parameter-declaration/declare-class-method-reserved-word/expected.json
+++ b/test/fixtures/flow/type-parameter-declaration/declare-class-method-reserved-word/expected.json
@@ -81,7 +81,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 20,
-              "end": 38,
+              "end": 37,
               "loc": {
                 "start": {
                   "line": 2,
@@ -89,7 +89,7 @@
                 },
                 "end": {
                   "line": 2,
-                  "column": 20
+                  "column": 19
                 }
               },
               "value": {
@@ -181,7 +181,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 41,
-              "end": 59,
+              "end": 58,
               "loc": {
                 "start": {
                   "line": 3,
@@ -189,7 +189,7 @@
                 },
                 "end": {
                   "line": 3,
-                  "column": 20
+                  "column": 19
                 }
               },
               "value": {
@@ -281,7 +281,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 62,
-              "end": 79,
+              "end": 78,
               "loc": {
                 "start": {
                   "line": 4,
@@ -289,7 +289,7 @@
                 },
                 "end": {
                   "line": 4,
-                  "column": 19
+                  "column": 18
                 }
               },
               "value": {
@@ -381,7 +381,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 82,
-              "end": 96,
+              "end": 95,
               "loc": {
                 "start": {
                   "line": 5,
@@ -389,7 +389,7 @@
                 },
                 "end": {
                   "line": 5,
-                  "column": 16
+                  "column": 15
                 }
               },
               "value": {
@@ -481,7 +481,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 99,
-              "end": 124,
+              "end": 123,
               "loc": {
                 "start": {
                   "line": 6,
@@ -489,7 +489,7 @@
                 },
                 "end": {
                   "line": 6,
-                  "column": 27
+                  "column": 26
                 }
               },
               "value": {
@@ -581,7 +581,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 127,
-              "end": 152,
+              "end": 151,
               "loc": {
                 "start": {
                   "line": 7,
@@ -589,7 +589,7 @@
                 },
                 "end": {
                   "line": 7,
-                  "column": 27
+                  "column": 26
                 }
               },
               "value": {
@@ -681,7 +681,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 155,
-              "end": 179,
+              "end": 178,
               "loc": {
                 "start": {
                   "line": 8,
@@ -689,7 +689,7 @@
                 },
                 "end": {
                   "line": 8,
-                  "column": 26
+                  "column": 25
                 }
               },
               "value": {
@@ -781,7 +781,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 182,
-              "end": 203,
+              "end": 202,
               "loc": {
                 "start": {
                   "line": 9,
@@ -789,7 +789,7 @@
                 },
                 "end": {
                   "line": 9,
-                  "column": 23
+                  "column": 22
                 }
               },
               "value": {

--- a/test/fixtures/flow/type-parameter-declaration/declare-interface-method-reserved-word/expected.json
+++ b/test/fixtures/flow/type-parameter-declaration/declare-interface-method-reserved-word/expected.json
@@ -81,7 +81,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 24,
-              "end": 42,
+              "end": 41,
               "loc": {
                 "start": {
                   "line": 2,
@@ -89,7 +89,7 @@
                 },
                 "end": {
                   "line": 2,
-                  "column": 20
+                  "column": 19
                 }
               },
               "value": {
@@ -181,7 +181,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 45,
-              "end": 63,
+              "end": 62,
               "loc": {
                 "start": {
                   "line": 3,
@@ -189,7 +189,7 @@
                 },
                 "end": {
                   "line": 3,
-                  "column": 20
+                  "column": 19
                 }
               },
               "value": {
@@ -281,7 +281,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 66,
-              "end": 83,
+              "end": 82,
               "loc": {
                 "start": {
                   "line": 4,
@@ -289,7 +289,7 @@
                 },
                 "end": {
                   "line": 4,
-                  "column": 19
+                  "column": 18
                 }
               },
               "value": {
@@ -381,7 +381,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 86,
-              "end": 100,
+              "end": 99,
               "loc": {
                 "start": {
                   "line": 5,
@@ -389,7 +389,7 @@
                 },
                 "end": {
                   "line": 5,
-                  "column": 16
+                  "column": 15
                 }
               },
               "value": {

--- a/test/fixtures/flow/type-parameter-declaration/interface-reserved-word/expected.json
+++ b/test/fixtures/flow/type-parameter-declaration/interface-reserved-word/expected.json
@@ -81,7 +81,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 16,
-              "end": 34,
+              "end": 33,
               "loc": {
                 "start": {
                   "line": 2,
@@ -89,7 +89,7 @@
                 },
                 "end": {
                   "line": 2,
-                  "column": 20
+                  "column": 19
                 }
               },
               "value": {
@@ -181,7 +181,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 37,
-              "end": 55,
+              "end": 54,
               "loc": {
                 "start": {
                   "line": 3,
@@ -189,7 +189,7 @@
                 },
                 "end": {
                   "line": 3,
-                  "column": 20
+                  "column": 19
                 }
               },
               "value": {
@@ -281,7 +281,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 58,
-              "end": 75,
+              "end": 74,
               "loc": {
                 "start": {
                   "line": 4,
@@ -289,7 +289,7 @@
                 },
                 "end": {
                   "line": 4,
-                  "column": 19
+                  "column": 18
                 }
               },
               "value": {
@@ -381,7 +381,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 78,
-              "end": 92,
+              "end": 91,
               "loc": {
                 "start": {
                   "line": 5,
@@ -389,7 +389,7 @@
                 },
                 "end": {
                   "line": 5,
-                  "column": 16
+                  "column": 15
                 }
               },
               "value": {

--- a/test/fixtures/flow/type-parameter-declaration/type-object-reserved-word/expected.json
+++ b/test/fixtures/flow/type-parameter-declaration/type-object-reserved-word/expected.json
@@ -79,7 +79,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 13,
-              "end": 31,
+              "end": 30,
               "loc": {
                 "start": {
                   "line": 2,
@@ -87,7 +87,7 @@
                 },
                 "end": {
                   "line": 2,
-                  "column": 20
+                  "column": 19
                 }
               },
               "value": {
@@ -179,7 +179,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 34,
-              "end": 52,
+              "end": 51,
               "loc": {
                 "start": {
                   "line": 3,
@@ -187,7 +187,7 @@
                 },
                 "end": {
                   "line": 3,
-                  "column": 20
+                  "column": 19
                 }
               },
               "value": {
@@ -279,7 +279,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 55,
-              "end": 72,
+              "end": 71,
               "loc": {
                 "start": {
                   "line": 4,
@@ -287,7 +287,7 @@
                 },
                 "end": {
                   "line": 4,
-                  "column": 19
+                  "column": 18
                 }
               },
               "value": {
@@ -379,7 +379,7 @@
             {
               "type": "ObjectTypeProperty",
               "start": 75,
-              "end": 89,
+              "end": 88,
               "loc": {
                 "start": {
                   "line": 5,
@@ -387,7 +387,7 @@
                 },
                 "end": {
                   "line": 5,
-                  "column": 16
+                  "column": 15
                 }
               },
               "value": {

--- a/test/fixtures/flow/typecasts/2/expected.json
+++ b/test/fixtures/flow/typecasts/2/expected.json
@@ -216,7 +216,7 @@
                 {
                   "type": "ObjectTypeProperty",
                   "start": 24,
-                  "end": 36,
+                  "end": 35,
                   "loc": {
                     "start": {
                       "line": 1,
@@ -224,7 +224,7 @@
                     },
                     "end": {
                       "line": 1,
-                      "column": 36
+                      "column": 35
                     }
                   },
                   "key": {


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes (ish)
| Tests added/pass? | yes/yes
| Fixed tickets     | Fixes #470
| License           | MIT

Double checked all of the fixtures match the locations in flow's parser
