### PR TITLE
Better error message for anonymous class declarations

### DIFF
--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -804,7 +804,7 @@ export default class StatementParser extends ExpressionParser {
       if (optionalId || !isStatement) {
         node.id = null;
       } else {
-        this.unexpected();
+        this.unexpected(null, "A class name is required");
       }
     }
   }

--- a/test/fixtures/es2015/uncategorised/263/options.json
+++ b/test/fixtures/es2015/uncategorised/263/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:6)"
+  "throws": "A class name is required (1:6)"
 }

--- a/test/fixtures/esprima/invalid-syntax/migrated_0261/options.json
+++ b/test/fixtures/esprima/invalid-syntax/migrated_0261/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:5)"
+  "throws": "A class name is required (1:5)"
 }

--- a/test/fixtures/esprima/invalid-syntax/migrated_0262/options.json
+++ b/test/fixtures/esprima/invalid-syntax/migrated_0262/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:5)"
+  "throws": "A class name is required (1:5)"
 }

--- a/test/fixtures/esprima/invalid-syntax/migrated_0263/options.json
+++ b/test/fixtures/esprima/invalid-syntax/migrated_0263/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token (1:5)"
+  "throws": "A class name is required (1:5)"
 }


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | yes
| Fixed tickets     | --
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->

Given code like:
```js
class {}
```
or 
```
class extends Bar {}
```
Instead of `Unexpected token (1:6)`, get `Class name required (1:6)`