### PR TITLE
Fix handling of anonymous parameters in `flowParseObjectTypeMethodish`.

### DIFF
--- a/src/plugins/flow.js
+++ b/src/plugins/flow.js
@@ -470,7 +470,7 @@ export default (superClass: Class<Parser>): Class<Parser> => class extends super
     }
 
     this.expect(tt.parenL);
-    while (this.match(tt.name)) {
+    while (!this.match(tt.parenR) && !this.match(tt.ellipsis)) {
       node.params.push(this.flowParseFunctionTypeParam());
       if (!this.match(tt.parenR)) {
         this.expect(tt.comma);

--- a/test/fixtures/flow/object-types/complex-param-types/actual.js
+++ b/test/fixtures/flow/object-types/complex-param-types/actual.js
@@ -1,0 +1,1 @@
+type o = { m(|int|bool): void }

--- a/test/fixtures/flow/object-types/complex-param-types/expected.json
+++ b/test/fixtures/flow/object-types/complex-param-types/expected.json
@@ -1,0 +1,238 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 31,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 31
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 31,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 31
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "TypeAlias",
+        "start": 0,
+        "end": 31,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 31
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 5,
+          "end": 6,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 5
+            },
+            "end": {
+              "line": 1,
+              "column": 6
+            },
+            "identifierName": "o"
+          },
+          "name": "o"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "ObjectTypeAnnotation",
+          "start": 9,
+          "end": 31,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 9
+            },
+            "end": {
+              "line": 1,
+              "column": 31
+            }
+          },
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "start": 11,
+              "end": 29,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 11
+                },
+                "end": {
+                  "line": 1,
+                  "column": 29
+                }
+              },
+              "key": {
+                "type": "Identifier",
+                "start": 11,
+                "end": 12,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 12
+                  },
+                  "identifierName": "m"
+                },
+                "name": "m"
+              },
+              "static": false,
+              "kind": "init",
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "start": 11,
+                "end": 29,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 29
+                  }
+                },
+                "params": [
+                  {
+                    "type": "FunctionTypeParam",
+                    "start": 13,
+                    "end": 22,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 13
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 22
+                      }
+                    },
+                    "name": null,
+                    "optional": false,
+                    "typeAnnotation": {
+                      "type": "UnionTypeAnnotation",
+                      "start": 13,
+                      "end": 22,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 13
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 22
+                        }
+                      },
+                      "types": [
+                        {
+                          "type": "GenericTypeAnnotation",
+                          "start": 14,
+                          "end": 17,
+                          "loc": {
+                            "start": {
+                              "line": 1,
+                              "column": 14
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 17
+                            }
+                          },
+                          "typeParameters": null,
+                          "id": {
+                            "type": "Identifier",
+                            "start": 14,
+                            "end": 17,
+                            "loc": {
+                              "start": {
+                                "line": 1,
+                                "column": 14
+                              },
+                              "end": {
+                                "line": 1,
+                                "column": 17
+                              },
+                              "identifierName": "int"
+                            },
+                            "name": "int"
+                          }
+                        },
+                        {
+                          "type": "BooleanTypeAnnotation",
+                          "start": 18,
+                          "end": 22,
+                          "loc": {
+                            "start": {
+                              "line": 1,
+                              "column": 18
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 22
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "rest": null,
+                "typeParameters": null,
+                "returnType": {
+                  "type": "VoidTypeAnnotation",
+                  "start": 25,
+                  "end": 29,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 25
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 29
+                    }
+                  }
+                }
+              },
+              "optional": false
+            }
+          ],
+          "indexers": [],
+          "exact": false
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     |
| License           | MIT

Analogous to the fix to `flowParseFunctionTypeParams` in https://github.com/babel/babylon/pull/338 (commit 407c97c9c2fe453fc2ae940c3d3b11c90d9dbc8e).
