### PR TITLE
☄️ Improve performance by removing all spread/rest usages

### DIFF
--- a/src/parser/expression.js
+++ b/src/parser/expression.js
@@ -753,7 +753,6 @@ export default class ExpressionParser extends LValParser {
     const elem = this.startNode();
     if (this.state.value === null) {
       if (!isTagged) {
-        // $FlowFixMe
         this.raise(this.state.invalidTemplateEscapePosition, "Invalid escape sequence in template");
       } else {
         this.state.invalidTemplateEscapePosition = null;

--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -1046,7 +1046,7 @@ export default class StatementParser extends ExpressionParser {
 
   // Parses a comma-separated list of module exports.
 
-  parseExportSpecifiers(): $ReadOnlyArray<N.ExportSpecifier> {
+  parseExportSpecifiers(): Array<N.ExportSpecifier> {
     const nodes = [];
     let first = true;
     let needsFrom;


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | 
| License           | MIT

This removes all spread/rest usages from flow and estree plugin which improves the performance on node 6.10.3 significantly.

Before:
```
name                            run  
./fixtures/angular.js           352ms
./fixtures/backbone.js          33ms 
./fixtures/ember.debug.js       933ms
./fixtures/jquery.js            183ms
./fixtures/react-with-addons.js 377ms
```

After:

```
name                            run  
./fixtures/angular.js           273ms
./fixtures/backbone.js          24ms 
./fixtures/ember.debug.js       707ms
./fixtures/jquery.js            141ms
./fixtures/react-with-addons.js 298ms
```

Test repo: https://github.com/danez/babylon_performance

Also had to fix some flow errors.