### PR TITLE
Fix location info on FunctionTypeParam nodes

### DIFF
--- a/src/plugins/flow.js
+++ b/src/plugins/flow.js
@@ -708,7 +708,7 @@ export default (superClass: Class<Parser>): Class<Parser> => class extends super
   }
 
   reinterpretTypeAsFunctionTypeParam(type: N.FlowType): N.FlowFunctionTypeParam {
-    const node = this.startNodeAt(type.start, type.loc);
+    const node = this.startNodeAt(type.start, type.loc.start);
     node.name = null;
     node.optional = false;
     node.typeAnnotation = type;
@@ -921,7 +921,7 @@ export default (superClass: Class<Parser>): Class<Parser> => class extends super
     const param = this.flowParsePrefixType();
     if (!this.state.noAnonFunctionType && this.eat(tt.arrow)) {
       // TODO: This should be a type error. Passing in a SourceLocation, and it expects a Position.
-      const node  = this.startNodeAt(param.start, param.loc);
+      const node  = this.startNodeAt(param.start, param.loc.start);
       node.params = [this.reinterpretTypeAsFunctionTypeParam(param)];
       node.rest = null;
       node.returnType = this.flowParseType();

--- a/test/fixtures/flow/anonymous-function-no-parens-types/good_01/expected.json
+++ b/test/fixtures/flow/anonymous-function-no-parens-types/good_01/expected.json
@@ -66,14 +66,8 @@
           "end": 23,
           "loc": {
             "start": {
-              "start": {
-                "line": 1,
-                "column": 9
-              },
-              "end": {
-                "line": 1,
-                "column": 15
-              }
+              "line": 1,
+              "column": 9
             },
             "end": {
               "line": 1,
@@ -87,14 +81,8 @@
               "end": 18,
               "loc": {
                 "start": {
-                  "start": {
-                    "line": 1,
-                    "column": 9
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 15
-                  }
+                  "line": 1,
+                  "column": 9
                 },
                 "end": {
                   "line": 1,

--- a/test/fixtures/flow/anonymous-function-no-parens-types/good_02/expected.json
+++ b/test/fixtures/flow/anonymous-function-no-parens-types/good_02/expected.json
@@ -66,14 +66,8 @@
           "end": 30,
           "loc": {
             "start": {
-              "start": {
-                "line": 1,
-                "column": 9
-              },
-              "end": {
-                "line": 1,
-                "column": 22
-              }
+              "line": 1,
+              "column": 9
             },
             "end": {
               "line": 1,
@@ -87,14 +81,8 @@
               "end": 25,
               "loc": {
                 "start": {
-                  "start": {
-                    "line": 1,
-                    "column": 9
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 22
-                  }
+                  "line": 1,
+                  "column": 9
                 },
                 "end": {
                   "line": 1,

--- a/test/fixtures/flow/anonymous-function-no-parens-types/good_05/expected.json
+++ b/test/fixtures/flow/anonymous-function-no-parens-types/good_05/expected.json
@@ -109,14 +109,8 @@
                   "end": 27,
                   "loc": {
                     "start": {
-                      "start": {
-                        "line": 1,
-                        "column": 14
-                      },
-                      "end": {
-                        "line": 1,
-                        "column": 20
-                      }
+                      "line": 1,
+                      "column": 14
                     },
                     "end": {
                       "line": 1,
@@ -130,14 +124,8 @@
                       "end": 23,
                       "loc": {
                         "start": {
-                          "start": {
-                            "line": 1,
-                            "column": 14
-                          },
-                          "end": {
-                            "line": 1,
-                            "column": 20
-                          }
+                          "line": 1,
+                          "column": 14
                         },
                         "end": {
                           "line": 1,

--- a/test/fixtures/flow/anonymous-function-no-parens-types/good_06/expected.json
+++ b/test/fixtures/flow/anonymous-function-no-parens-types/good_06/expected.json
@@ -96,14 +96,8 @@
               "end": 35,
               "loc": {
                 "start": {
-                  "start": {
-                    "line": 1,
-                    "column": 18
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 24
-                  }
+                  "line": 1,
+                  "column": 18
                 },
                 "end": {
                   "line": 1,
@@ -117,14 +111,8 @@
                   "end": 27,
                   "loc": {
                     "start": {
-                      "start": {
-                        "line": 1,
-                        "column": 18
-                      },
-                      "end": {
-                        "line": 1,
-                        "column": 24
-                      }
+                      "line": 1,
+                      "column": 18
                     },
                     "end": {
                       "line": 1,

--- a/test/fixtures/flow/anonymous-function-no-parens-types/good_07/expected.json
+++ b/test/fixtures/flow/anonymous-function-no-parens-types/good_07/expected.json
@@ -96,14 +96,8 @@
               "end": 35,
               "loc": {
                 "start": {
-                  "start": {
-                    "line": 1,
-                    "column": 18
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 24
-                  }
+                  "line": 1,
+                  "column": 18
                 },
                 "end": {
                   "line": 1,
@@ -117,14 +111,8 @@
                   "end": 27,
                   "loc": {
                     "start": {
-                      "start": {
-                        "line": 1,
-                        "column": 18
-                      },
-                      "end": {
-                        "line": 1,
-                        "column": 24
-                      }
+                      "line": 1,
+                      "column": 18
                     },
                     "end": {
                       "line": 1,

--- a/test/fixtures/flow/anonymous-function-no-parens-types/good_08/expected.json
+++ b/test/fixtures/flow/anonymous-function-no-parens-types/good_08/expected.json
@@ -66,14 +66,8 @@
           "end": 27,
           "loc": {
             "start": {
-              "start": {
-                "line": 1,
-                "column": 9
-              },
-              "end": {
-                "line": 1,
-                "column": 16
-              }
+              "line": 1,
+              "column": 9
             },
             "end": {
               "line": 1,
@@ -87,14 +81,8 @@
               "end": 19,
               "loc": {
                 "start": {
-                  "start": {
-                    "line": 1,
-                    "column": 9
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 16
-                  }
+                  "line": 1,
+                  "column": 9
                 },
                 "end": {
                   "line": 1,

--- a/test/fixtures/flow/anonymous-function-no-parens-types/good_09/expected.json
+++ b/test/fixtures/flow/anonymous-function-no-parens-types/good_09/expected.json
@@ -66,14 +66,8 @@
           "end": 28,
           "loc": {
             "start": {
-              "start": {
-                "line": 1,
-                "column": 9
-              },
-              "end": {
-                "line": 1,
-                "column": 17
-              }
+              "line": 1,
+              "column": 9
             },
             "end": {
               "line": 1,
@@ -87,14 +81,8 @@
               "end": 20,
               "loc": {
                 "start": {
-                  "start": {
-                    "line": 1,
-                    "column": 9
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 17
-                  }
+                  "line": 1,
+                  "column": 9
                 },
                 "end": {
                   "line": 1,

--- a/test/fixtures/flow/anonymous-function-no-parens-types/good_10/expected.json
+++ b/test/fixtures/flow/anonymous-function-no-parens-types/good_10/expected.json
@@ -81,20 +81,8 @@
               "end": 27,
               "loc": {
                 "start": {
-                  "start": {
-                    "start": {
-                      "line": 1,
-                      "column": 10
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 16
-                    }
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 27
-                  }
+                  "line": 1,
+                  "column": 10
                 },
                 "end": {
                   "line": 1,
@@ -109,14 +97,8 @@
                 "end": 27,
                 "loc": {
                   "start": {
-                    "start": {
-                      "line": 1,
-                      "column": 10
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 16
-                    }
+                    "line": 1,
+                    "column": 10
                   },
                   "end": {
                     "line": 1,
@@ -130,14 +112,8 @@
                     "end": 19,
                     "loc": {
                       "start": {
-                        "start": {
-                          "line": 1,
-                          "column": 10
-                        },
-                        "end": {
-                          "line": 1,
-                          "column": 16
-                        }
+                        "line": 1,
+                        "column": 10
                       },
                       "end": {
                         "line": 1,

--- a/test/fixtures/flow/anonymous-function-no-parens-types/good_11/expected.json
+++ b/test/fixtures/flow/anonymous-function-no-parens-types/good_11/expected.json
@@ -66,14 +66,8 @@
           "end": 35,
           "loc": {
             "start": {
-              "start": {
-                "line": 1,
-                "column": 9
-              },
-              "end": {
-                "line": 1,
-                "column": 15
-              }
+              "line": 1,
+              "column": 9
             },
             "end": {
               "line": 1,
@@ -87,14 +81,8 @@
               "end": 18,
               "loc": {
                 "start": {
-                  "start": {
-                    "line": 1,
-                    "column": 9
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 15
-                  }
+                  "line": 1,
+                  "column": 9
                 },
                 "end": {
                   "line": 1,

--- a/test/fixtures/flow/anonymous-function-no-parens-types/good_12/expected.json
+++ b/test/fixtures/flow/anonymous-function-no-parens-types/good_12/expected.json
@@ -66,14 +66,8 @@
           "end": 36,
           "loc": {
             "start": {
-              "start": {
-                "line": 1,
-                "column": 9
-              },
-              "end": {
-                "line": 1,
-                "column": 15
-              }
+              "line": 1,
+              "column": 9
             },
             "end": {
               "line": 1,
@@ -87,14 +81,8 @@
               "end": 18,
               "loc": {
                 "start": {
-                  "start": {
-                    "line": 1,
-                    "column": 9
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 15
-                  }
+                  "line": 1,
+                  "column": 9
                 },
                 "end": {
                   "line": 1,
@@ -127,14 +115,8 @@
             "end": 36,
             "loc": {
               "start": {
-                "start": {
-                  "line": 1,
-                  "column": 19
-                },
-                "end": {
-                  "line": 1,
-                  "column": 26
-                }
+                "line": 1,
+                "column": 19
               },
               "end": {
                 "line": 1,
@@ -148,14 +130,8 @@
                 "end": 29,
                 "loc": {
                   "start": {
-                    "start": {
-                      "line": 1,
-                      "column": 19
-                    },
-                    "end": {
-                      "line": 1,
-                      "column": 26
-                    }
+                    "line": 1,
+                    "column": 19
                   },
                   "end": {
                     "line": 1,

--- a/test/fixtures/flow/anonymous-function-types/good_03/expected.json
+++ b/test/fixtures/flow/anonymous-function-types/good_03/expected.json
@@ -81,14 +81,8 @@
               "end": 16,
               "loc": {
                 "start": {
-                  "start": {
-                    "line": 1,
-                    "column": 10
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 16
-                  }
+                  "line": 1,
+                  "column": 10
                 },
                 "end": {
                   "line": 1,

--- a/test/fixtures/flow/anonymous-function-types/good_04/expected.json
+++ b/test/fixtures/flow/anonymous-function-types/good_04/expected.json
@@ -81,14 +81,8 @@
               "end": 17,
               "loc": {
                 "start": {
-                  "start": {
-                    "line": 1,
-                    "column": 10
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 16
-                  }
+                  "line": 1,
+                  "column": 10
                 },
                 "end": {
                   "line": 1,

--- a/test/fixtures/flow/anonymous-function-types/good_05/expected.json
+++ b/test/fixtures/flow/anonymous-function-types/good_05/expected.json
@@ -81,14 +81,8 @@
               "end": 23,
               "loc": {
                 "start": {
-                  "start": {
-                    "line": 1,
-                    "column": 10
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 23
-                  }
+                  "line": 1,
+                  "column": 10
                 },
                 "end": {
                   "line": 1,

--- a/test/fixtures/flow/anonymous-function-types/good_06/expected.json
+++ b/test/fixtures/flow/anonymous-function-types/good_06/expected.json
@@ -81,14 +81,8 @@
               "end": 24,
               "loc": {
                 "start": {
-                  "start": {
-                    "line": 1,
-                    "column": 10
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 23
-                  }
+                  "line": 1,
+                  "column": 10
                 },
                 "end": {
                   "line": 1,

--- a/test/fixtures/flow/anonymous-function-types/good_09/expected.json
+++ b/test/fixtures/flow/anonymous-function-types/good_09/expected.json
@@ -81,14 +81,8 @@
               "end": 24,
               "loc": {
                 "start": {
-                  "start": {
-                    "line": 1,
-                    "column": 10
-                  },
-                  "end": {
-                    "line": 1,
-                    "column": 23
-                  }
+                  "line": 1,
+                  "column": 10
                 },
                 "end": {
                   "line": 1,

--- a/test/fixtures/flow/anonymous-function-types/good_13/expected.json
+++ b/test/fixtures/flow/anonymous-function-types/good_13/expected.json
@@ -124,14 +124,8 @@
                       "end": 21,
                       "loc": {
                         "start": {
-                          "start": {
-                            "line": 1,
-                            "column": 15
-                          },
-                          "end": {
-                            "line": 1,
-                            "column": 21
-                          }
+                          "line": 1,
+                          "column": 15
                         },
                         "end": {
                           "line": 1,

--- a/test/fixtures/flow/regression/issue-321/expected.json
+++ b/test/fixtures/flow/regression/issue-321/expected.json
@@ -108,14 +108,8 @@
                       "end": 19,
                       "loc": {
                         "start": {
-                          "start": {
-                            "line": 1,
-                            "column": 12
-                          },
-                          "end": {
-                            "line": 1,
-                            "column": 18
-                          }
+                          "line": 1,
+                          "column": 12
                         },
                         "end": {
                           "line": 1,
@@ -400,14 +394,8 @@
                       "end": 77,
                       "loc": {
                         "start": {
-                          "start": {
-                            "line": 2,
-                            "column": 12
-                          },
-                          "end": {
-                            "line": 2,
-                            "column": 18
-                          }
+                          "line": 2,
+                          "column": 12
                         },
                         "end": {
                           "line": 2,


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | yes
| Fixed tickets     |
| License           | MIT

The location info was wrong since these got parsing support in Novemeber (in #197 ). This is in turn breaking Recast, which is in turn breaking `jscodeshift` on programs using Flow function param annotations without names.

I am a complete n00b here, how long will it take for this fix to make it to npm and what version will it go out in? (can it be patched on 6?). Thanks!