### PR TITLE
Fix v8 deopts

### DIFF
--- a/src/tokenizer/index.js
+++ b/src/tokenizer/index.js
@@ -78,6 +78,7 @@ export default class Tokenizer extends LocationParser {
     super();
     this.state = new State;
     this.state.init(options, input);
+    this.isLookahead = false;
   }
 
   // Move to the next token
@@ -127,7 +128,7 @@ export default class Tokenizer extends LocationParser {
     this.next();
     this.isLookahead = false;
 
-    const curr = this.state.clone(true);
+    const curr = this.state;
     this.state = old;
     return curr;
   }
@@ -225,9 +226,10 @@ export default class Tokenizer extends LocationParser {
     const start = this.state.pos;
     const startLoc = this.state.curPosition();
     let ch = this.input.charCodeAt(this.state.pos += startSkip);
-    while (this.state.pos < this.input.length && ch !== 10 && ch !== 13 && ch !== 8232 && ch !== 8233) {
-      ++this.state.pos;
-      ch = this.input.charCodeAt(this.state.pos);
+    if (this.state.pos < this.input.length) {
+      while (ch !== 10 && ch !== 13 && ch !== 8232 && ch !== 8233 && ++this.state.pos < this.input.length) {
+        ch = this.input.charCodeAt(this.state.pos);
+      }
     }
 
     this.pushComment(false, this.input.slice(start + startSkip, this.state.pos), start, this.state.pos, startLoc, this.state.curPosition());

--- a/src/tokenizer/state.js
+++ b/src/tokenizer/state.js
@@ -40,6 +40,8 @@ export default class State {
     this.trailingComments = [];
     this.leadingComments  = [];
     this.commentStack     = [];
+    // $FlowIgnore
+    this.commentPreviousNode = null;
 
     this.pos = this.lineStart = 0;
     this.curLine = options.startLine;

--- a/src/util/location.js
+++ b/src/util/location.js
@@ -23,6 +23,7 @@ export class SourceLocation {
   start: Position;
   end: Position;
   filename: string;
+  identifierName: ?string;
 
   constructor(start: Position, end?: Position) {
     this.start = start;


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | n
| Breaking change?  | n
| New feature?      | n
| Deprecations?     | n
| Spec compliancy?  | n
| Tests added/pass? | y
| Fixed tickets     | 
| License           | MIT

This fixes some v8 deopts, the biggest one is the loop change in `skipLineComment()`. It was deoptimized because` this.input.charCodeAt(this.state.pos);` was triggering an `out of bounce deopt`.

The removed `clone()` seems to be unnecessary to me?

The rest is about hidden class deopts, although I still see deopts for `this.state` in the beginning of the run, but that is normal? At least I couldn't find more dynamic fields which are not initialized.

The overall performance did not change with this changes.