### PR TITLE
Follow-up on Decorators PR

### DIFF
--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -173,6 +173,11 @@ export default class StatementParser extends ExpressionParser {
       return;
     }
 
+    // special error for the common case of @dec export class
+    if (!allowExport && this.match(tt._export)) {
+      this.raise(this.state.start, "Using the export keyword between decorators and class is disallowed. Please use `export @dec class` instead");
+    }
+
     if (!this.match(tt._class)) {
       this.raise(this.state.start, "Leading decorators must be attached to a class declaration");
     }

--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -177,7 +177,7 @@ export default class StatementParser extends ExpressionParser {
 
     // special error for the common case of @dec export class
     if (!allowExport && this.match(tt._export)) {
-      this.raise(this.state.start, "Using the export keyword between decorators and class is disallowed. Please use `export @dec class` instead");
+      this.raise(this.state.start, "Using the export keyword between a decorator and a class is not allowed. Please use `export @dec class` instead");
     }
 
     if (!this.match(tt._class)) {

--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -171,13 +171,12 @@ export default class StatementParser extends ExpressionParser {
       currentContextDecorators.push(decorator);
     }
 
-    if (allowExport && this.match(tt._export)) {
-      return;
-    }
-
-    // special error for the common case of @dec export class
-    if (!allowExport && this.match(tt._export)) {
-      this.raise(this.state.start, "Using the export keyword between a decorator and a class is not allowed. Please use `export @dec class` instead");
+    if (this.match(tt._export)) {
+      if (allowExport) {
+        return;
+      } else {
+        this.raise(this.state.start, "Using the export keyword between a decorator and a class is not allowed. Please use `export @dec class` instead");
+      }
     }
 
     if (!this.match(tt._class)) {

--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -150,12 +150,13 @@ export default class StatementParser extends ExpressionParser {
   }
 
   takeDecorators(node: N.HasDecorators): void {
-    if (this.state.decorators.length) {
-      node.decorators = this.state.decorators;
+    const decorators = this.state.decoratorStack[this.state.decoratorStack.length - 1];
+    if (decorators.length) {
+      node.decorators = decorators;
       if (this.hasPlugin("decorators2")) {
-        this.resetStartLocationFromNode(node, this.state.decorators[0]);
+        this.resetStartLocationFromNode(node, decorators[0]);
       }
-      this.state.decorators = [];
+      this.state.decoratorStack[this.state.decoratorStack.length - 1] = [];
     }
   }
 
@@ -164,9 +165,10 @@ export default class StatementParser extends ExpressionParser {
       allowExport = false;
     }
 
+    const currentContextDecorators = this.state.decoratorStack[this.state.decoratorStack.length - 1];
     while (this.match(tt.at)) {
       const decorator = this.parseDecorator();
-      this.state.decorators.push(decorator);
+      currentContextDecorators.push(decorator);
     }
 
     if (allowExport && this.match(tt._export)) {
@@ -207,7 +209,11 @@ export default class StatementParser extends ExpressionParser {
       if (this.eat(tt.parenL)) {
         const node = this.startNodeAt(startPos, startLoc);
         node.callee = expr;
+        // Every time a decorator class expression is evaluated, a new empty array is pushed onto the stack
+        // So that the decorators of any nested class expressions will be dealt with separately
+        this.state.decoratorStack.push([]);
         node.arguments = this.parseCallExpressionArguments(tt.parenR, false);
+        this.state.decoratorStack.pop();
         expr = this.finishNode(node, "CallExpression");
         this.toReferencedList(expr.arguments);
       }
@@ -1043,7 +1049,8 @@ export default class StatementParser extends ExpressionParser {
       }
     }
 
-    if (this.state.decorators.length) {
+    const currentContextDecorators = this.state.decoratorStack[this.state.decoratorStack.length - 1];
+    if (currentContextDecorators.length) {
       const isClass = node.declaration && (node.declaration.type === "ClassDeclaration" || node.declaration.type === "ClassExpression");
       if (!node.declaration || !isClass) {
         throw this.raise(node.start, "You can only use decorators on an export when exporting a class");

--- a/src/tokenizer/state.js
+++ b/src/tokenizer/state.js
@@ -90,7 +90,8 @@ export default class State {
   labels: Array<{ kind: ?("loop" | "switch"), statementStart?: number }>;
 
   // Leading decorators. Last element of the stack represents the decorators in current context.
-  // Supports nesting of decorators, e.g. @foo(@bar class {}) class {}
+  // Supports nesting of decorators, e.g. @foo(@bar class inner {}) class outer {}
+  // where @foo belongs to the outer class and @bar to the inner
   decoratorStack: Array<Array<N.Decorator>>;
 
   // Token store.

--- a/src/tokenizer/state.js
+++ b/src/tokenizer/state.js
@@ -31,7 +31,7 @@ export default class State {
 
     this.labels = [];
 
-    this.decorators = [];
+    this.decoratorStack = [[]];
 
     this.tokens = [];
 
@@ -89,8 +89,9 @@ export default class State {
   // Labels in scope.
   labels: Array<{ kind: ?("loop" | "switch"), statementStart?: number }>;
 
-  // Leading decorators.
-  decorators: Array<N.Decorator>;
+  // Leading decorators. Last element of the stack represents the decorators in current context.
+  // Supports nesting of decorators, e.g. @foo(@bar class {}) class {}
+  decoratorStack: Array<Array<N.Decorator>>;
 
   // Token store.
   tokens: Array<Token | N.Comment>;

--- a/test/fixtures/experimental/decorators-2/decoratorception-class/actual.js
+++ b/test/fixtures/experimental/decorators-2/decoratorception-class/actual.js
@@ -1,0 +1,6 @@
+@outer({
+  store: @inner class Foo {}
+})
+class Bar {
+  
+}

--- a/test/fixtures/experimental/decorators-2/decoratorception-class/expected.json
+++ b/test/fixtures/experimental/decorators-2/decoratorception-class/expected.json
@@ -1,0 +1,269 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 57,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 6,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 57,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 6,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 57,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 1
+          }
+        },
+        "decorators": [
+          {
+            "type": "Decorator",
+            "start": 0,
+            "end": 40,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 3,
+                "column": 2
+              }
+            },
+            "expression": {
+              "type": "CallExpression",
+              "start": 1,
+              "end": 40,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 1
+                },
+                "end": {
+                  "line": 3,
+                  "column": 2
+                }
+              },
+              "callee": {
+                "type": "Identifier",
+                "start": 1,
+                "end": 6,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 1
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 6
+                  },
+                  "identifierName": "outer"
+                },
+                "name": "outer"
+              },
+              "arguments": [
+                {
+                  "type": "ObjectExpression",
+                  "start": 7,
+                  "end": 39,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 1
+                    }
+                  },
+                  "properties": [
+                    {
+                      "type": "ObjectProperty",
+                      "start": 11,
+                      "end": 37,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 2
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 28
+                        }
+                      },
+                      "method": false,
+                      "computed": false,
+                      "key": {
+                        "type": "Identifier",
+                        "start": 11,
+                        "end": 16,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 2
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 7
+                          },
+                          "identifierName": "store"
+                        },
+                        "name": "store"
+                      },
+                      "shorthand": false,
+                      "value": {
+                        "type": "ClassExpression",
+                        "start": 18,
+                        "end": 37,
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 9
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 28
+                          }
+                        },
+                        "decorators": [
+                          {
+                            "type": "Decorator",
+                            "start": 18,
+                            "end": 24,
+                            "loc": {
+                              "start": {
+                                "line": 2,
+                                "column": 9
+                              },
+                              "end": {
+                                "line": 2,
+                                "column": 15
+                              }
+                            },
+                            "expression": {
+                              "type": "Identifier",
+                              "start": 19,
+                              "end": 24,
+                              "loc": {
+                                "start": {
+                                  "line": 2,
+                                  "column": 10
+                                },
+                                "end": {
+                                  "line": 2,
+                                  "column": 15
+                                },
+                                "identifierName": "inner"
+                              },
+                              "name": "inner"
+                            }
+                          }
+                        ],
+                        "id": {
+                          "type": "Identifier",
+                          "start": 31,
+                          "end": 34,
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 22
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 25
+                            },
+                            "identifierName": "Foo"
+                          },
+                          "name": "Foo"
+                        },
+                        "superClass": null,
+                        "body": {
+                          "type": "ClassBody",
+                          "start": 35,
+                          "end": 37,
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 26
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 28
+                            }
+                          },
+                          "body": []
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "id": {
+          "type": "Identifier",
+          "start": 47,
+          "end": 50,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 6
+            },
+            "end": {
+              "line": 4,
+              "column": 9
+            },
+            "identifierName": "Bar"
+          },
+          "name": "Bar"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 51,
+          "end": 57,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 10
+            },
+            "end": {
+              "line": 6,
+              "column": 1
+            }
+          },
+          "body": []
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/experimental/decorators-2/decoratorception-method/actual.js
+++ b/test/fixtures/experimental/decorators-2/decoratorception-method/actual.js
@@ -1,0 +1,9 @@
+class Bar{
+  @outer(
+    @classDec class { 
+      @inner 
+      innerMethod() {} 
+    }
+  )
+  outerMethod() {}
+}

--- a/test/fixtures/experimental/decorators-2/decoratorception-method/expected.json
+++ b/test/fixtures/experimental/decorators-2/decoratorception-method/expected.json
@@ -1,0 +1,351 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 112,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 9,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 112,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 9,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 112,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 9,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 9,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 9
+            },
+            "identifierName": "Bar"
+          },
+          "name": "Bar"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 9,
+          "end": 112,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 9
+            },
+            "end": {
+              "line": 9,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassMethod",
+              "start": 13,
+              "end": 110,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 8,
+                  "column": 18
+                }
+              },
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start": 13,
+                  "end": 91,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 7,
+                      "column": 3
+                    }
+                  },
+                  "expression": {
+                    "type": "CallExpression",
+                    "start": 14,
+                    "end": 91,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 3
+                      },
+                      "end": {
+                        "line": 7,
+                        "column": 3
+                      }
+                    },
+                    "callee": {
+                      "type": "Identifier",
+                      "start": 14,
+                      "end": 19,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 3
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 8
+                        },
+                        "identifierName": "outer"
+                      },
+                      "name": "outer"
+                    },
+                    "arguments": [
+                      {
+                        "type": "ClassExpression",
+                        "start": 25,
+                        "end": 87,
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 4
+                          },
+                          "end": {
+                            "line": 6,
+                            "column": 5
+                          }
+                        },
+                        "decorators": [
+                          {
+                            "type": "Decorator",
+                            "start": 25,
+                            "end": 34,
+                            "loc": {
+                              "start": {
+                                "line": 3,
+                                "column": 4
+                              },
+                              "end": {
+                                "line": 3,
+                                "column": 13
+                              }
+                            },
+                            "expression": {
+                              "type": "Identifier",
+                              "start": 26,
+                              "end": 34,
+                              "loc": {
+                                "start": {
+                                  "line": 3,
+                                  "column": 5
+                                },
+                                "end": {
+                                  "line": 3,
+                                  "column": 13
+                                },
+                                "identifierName": "classDec"
+                              },
+                              "name": "classDec"
+                            }
+                          }
+                        ],
+                        "id": null,
+                        "superClass": null,
+                        "body": {
+                          "type": "ClassBody",
+                          "start": 41,
+                          "end": 87,
+                          "loc": {
+                            "start": {
+                              "line": 3,
+                              "column": 20
+                            },
+                            "end": {
+                              "line": 6,
+                              "column": 5
+                            }
+                          },
+                          "body": [
+                            {
+                              "type": "ClassMethod",
+                              "start": 50,
+                              "end": 80,
+                              "loc": {
+                                "start": {
+                                  "line": 4,
+                                  "column": 6
+                                },
+                                "end": {
+                                  "line": 5,
+                                  "column": 22
+                                }
+                              },
+                              "decorators": [
+                                {
+                                  "type": "Decorator",
+                                  "start": 50,
+                                  "end": 56,
+                                  "loc": {
+                                    "start": {
+                                      "line": 4,
+                                      "column": 6
+                                    },
+                                    "end": {
+                                      "line": 4,
+                                      "column": 12
+                                    }
+                                  },
+                                  "expression": {
+                                    "type": "Identifier",
+                                    "start": 51,
+                                    "end": 56,
+                                    "loc": {
+                                      "start": {
+                                        "line": 4,
+                                        "column": 7
+                                      },
+                                      "end": {
+                                        "line": 4,
+                                        "column": 12
+                                      },
+                                      "identifierName": "inner"
+                                    },
+                                    "name": "inner"
+                                  }
+                                }
+                              ],
+                              "static": false,
+                              "computed": false,
+                              "key": {
+                                "type": "Identifier",
+                                "start": 64,
+                                "end": 75,
+                                "loc": {
+                                  "start": {
+                                    "line": 5,
+                                    "column": 6
+                                  },
+                                  "end": {
+                                    "line": 5,
+                                    "column": 17
+                                  },
+                                  "identifierName": "innerMethod"
+                                },
+                                "name": "innerMethod"
+                              },
+                              "kind": "method",
+                              "id": null,
+                              "generator": false,
+                              "expression": false,
+                              "async": false,
+                              "params": [],
+                              "body": {
+                                "type": "BlockStatement",
+                                "start": 78,
+                                "end": 80,
+                                "loc": {
+                                  "start": {
+                                    "line": 5,
+                                    "column": 20
+                                  },
+                                  "end": {
+                                    "line": 5,
+                                    "column": 22
+                                  }
+                                },
+                                "body": [],
+                                "directives": []
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "static": false,
+              "computed": false,
+              "key": {
+                "type": "Identifier",
+                "start": 94,
+                "end": 105,
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 13
+                  },
+                  "identifierName": "outerMethod"
+                },
+                "name": "outerMethod"
+              },
+              "kind": "method",
+              "id": null,
+              "generator": false,
+              "expression": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start": 108,
+                "end": 110,
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 18
+                  }
+                },
+                "body": [],
+                "directives": []
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/experimental/decorators-2/no-export-decorators-on-class/options.json
+++ b/test/fixtures/experimental/decorators-2/no-export-decorators-on-class/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "throws": "Leading decorators must be attached to a class declaration (2:0)"
+  "throws": "Using the export keyword between decorators and class is disallowed. Please use `export @dec class` instead (2:0)"
 }

--- a/test/fixtures/experimental/decorators-2/no-export-decorators-on-class/options.json
+++ b/test/fixtures/experimental/decorators-2/no-export-decorators-on-class/options.json
@@ -1,4 +1,4 @@
 {
   "sourceType": "module",
-  "throws": "Using the export keyword between decorators and class is disallowed. Please use `export @dec class` instead (2:0)"
+  "throws": "Using the export keyword between a decorator and a class is not allowed. Please use `export @dec class` instead (2:0)"
 }

--- a/test/fixtures/experimental/decorators-2/static-method/actual.js
+++ b/test/fixtures/experimental/decorators-2/static-method/actual.js
@@ -1,0 +1,4 @@
+class Foo {
+  @dec
+  static bar() {}
+}

--- a/test/fixtures/experimental/decorators-2/static-method/expected.json
+++ b/test/fixtures/experimental/decorators-2/static-method/expected.json
@@ -1,0 +1,175 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 38,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 1
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 38,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 1
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "ClassDeclaration",
+        "start": 0,
+        "end": 38,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 1
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 6,
+          "end": 9,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 9
+            },
+            "identifierName": "Foo"
+          },
+          "name": "Foo"
+        },
+        "superClass": null,
+        "body": {
+          "type": "ClassBody",
+          "start": 10,
+          "end": 38,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 10
+            },
+            "end": {
+              "line": 4,
+              "column": 1
+            }
+          },
+          "body": [
+            {
+              "type": "ClassMethod",
+              "start": 14,
+              "end": 36,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 17
+                }
+              },
+              "decorators": [
+                {
+                  "type": "Decorator",
+                  "start": 14,
+                  "end": 18,
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 6
+                    }
+                  },
+                  "expression": {
+                    "type": "Identifier",
+                    "start": 15,
+                    "end": 18,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 3
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 6
+                      },
+                      "identifierName": "dec"
+                    },
+                    "name": "dec"
+                  }
+                }
+              ],
+              "static": true,
+              "computed": false,
+              "key": {
+                "type": "Identifier",
+                "start": 28,
+                "end": 31,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 12
+                  },
+                  "identifierName": "bar"
+                },
+                "name": "bar"
+              },
+              "kind": "method",
+              "id": null,
+              "generator": false,
+              "expression": false,
+              "async": false,
+              "params": [],
+              "body": {
+                "type": "BlockStatement",
+                "start": 34,
+                "end": 36,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 15
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 17
+                  }
+                },
+                "body": [],
+                "directives": []
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | yes
| Fixed tickets     | #524, #14
| License           | MIT 

<!-- Describe your changes below in as much detail as possible -->

1. [commit 1](https://github.com/babel/babylon/commit/add8e4ad13b4a44de409e283e99679a904012317) Add a more helpful error message for when `@dec export class {}` is encountered, suggesting the user to use `export @dec class {}` instead (only happens in the new decorators2 plugin). [As requested](https://github.com/babel/babylon/pull/587#pullrequestreview-45734043) by @hzoo
2. [commit 2](https://github.com/babel/babylon/commit/37fa77e84f4ebe8f7fd6ea1fc3e79eae875652db) Fixes #524 by using a stack of decorators to allow nesting instead of using one global list of decorators. Earlier the following code would have attached both `@outer` and `@inner` to Foo but now it works correctly
   ```js
   @outer(@inner class Foo {})
   class Bar {}
   ```
3. [commit 3](https://github.com/babel/babylon/commit/2c8fc756434a7980d23ddcbff5347ad57ef30884) adds the only useful test case I found in #14. Rest of tests are either already present or refer to an outdated version of the spec. It can now be closed.