### PR TITLE
Add static private class field support

### DIFF
--- a/ast/spec.md
+++ b/ast/spec.md
@@ -1056,6 +1056,7 @@ interface ClassProperty <: Node {
   type: "ClassProperty";
   key: Expression;
   value: Expression;
+  static: boolean;
   computed: boolean;
 }
 ```
@@ -1067,6 +1068,7 @@ interface ClassPrivateProperty <: Node {
   type: "ClassPrivateProperty";
   key: Identifier;
   value: Expression;
+  static: boolean;
 }
 ```
 

--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -922,15 +922,6 @@ export default class StatementParser extends ExpressionParser {
     const method: N.ClassMethod = memberAny;
     const prop: N.ClassProperty = memberAny;
 
-    if (this.hasPlugin("classPrivateProperties") && this.match(tt.hash)) {
-      // Private property
-      this.next();
-      const privateProp: N.ClassPrivateProperty = memberAny;
-      privateProp.key = this.parseIdentifier(true);
-      classBody.body.push(this.parsePrivateClassProperty(privateProp));
-      return;
-    }
-
     let isStatic = false;
     if (this.match(tt.name) && this.state.value === "static") {
       const key = this.parseIdentifier(true); // eats 'static'
@@ -958,6 +949,16 @@ export default class StatementParser extends ExpressionParser {
       }
       // otherwise something static
       isStatic = true;
+    }
+
+    if (this.hasPlugin("classPrivateProperties") && this.match(tt.hash)) {
+      // Private property
+      this.next();
+      const privateProp: N.ClassPrivateProperty = memberAny;
+      privateProp.key = this.parseIdentifier(true);
+      privateProp.static = isStatic;
+      classBody.body.push(this.parsePrivateClassProperty(privateProp));
+      return;
     }
 
     this.parseClassMemberWithIsStatic(classBody, member, state, isStatic);

--- a/src/types.js
+++ b/src/types.js
@@ -680,6 +680,7 @@ export type ClassPrivateProperty = NodeBase & {
   type: "ClassPrivateProperty",
   key: Identifier,
   value: ?Expression, // TODO: Not in spec that this is nullable.
+  static: boolean,
 };
 
 export type OptClassDeclaration = ClassBase &

--- a/test/fixtures/experimental/class-private-properties/delete-non-private/expected.json
+++ b/test/fixtures/experimental/class-private-properties/delete-non-private/expected.json
@@ -106,6 +106,7 @@
                 },
                 "name": "x"
               },
+              "static": false,
               "value": null
             },
             {

--- a/test/fixtures/experimental/class-private-properties/inline/expected.json
+++ b/test/fixtures/experimental/class-private-properties/inline/expected.json
@@ -106,6 +106,7 @@
                 },
                 "name": "x"
               },
+              "static": false,
               "value": null
             },
             {
@@ -139,6 +140,7 @@
                 },
                 "name": "y"
               },
+              "static": false,
               "value": null
             }
           ]
@@ -222,6 +224,7 @@
                 },
                 "name": "x"
               },
+              "static": false,
               "value": {
                 "type": "NumericLiteral",
                 "start": 36,
@@ -274,6 +277,7 @@
                 },
                 "name": "y"
               },
+              "static": false,
               "value": {
                 "type": "NumericLiteral",
                 "start": 44,

--- a/test/fixtures/experimental/class-private-properties/nested/expected.json
+++ b/test/fixtures/experimental/class-private-properties/nested/expected.json
@@ -106,6 +106,7 @@
                 },
                 "name": "x"
               },
+              "static": false,
               "value": {
                 "type": "NumericLiteral",
                 "start": 23,
@@ -158,6 +159,7 @@
                 },
                 "name": "y"
               },
+              "static": false,
               "value": {
                 "type": "NumericLiteral",
                 "start": 35,
@@ -677,6 +679,7 @@
                                 },
                                 "name": "x"
                               },
+                              "static": false,
                               "value": {
                                 "type": "NumericLiteral",
                                 "start": 151,
@@ -729,6 +732,7 @@
                                 },
                                 "name": "y"
                               },
+                              "static": false,
                               "value": {
                                 "type": "NumericLiteral",
                                 "start": 171,

--- a/test/fixtures/experimental/class-private-properties/pbn-success/expected.json
+++ b/test/fixtures/experimental/class-private-properties/pbn-success/expected.json
@@ -106,6 +106,7 @@
                 },
                 "name": "x"
               },
+              "static": false,
               "value": null
             },
             {
@@ -139,6 +140,7 @@
                 },
                 "name": "y"
               },
+              "static": false,
               "value": null
             },
             {

--- a/test/fixtures/experimental/class-private-properties/static/actual.js
+++ b/test/fixtures/experimental/class-private-properties/static/actual.js
@@ -1,0 +1,4 @@
+class A {
+  static #x;
+  static #y = 1;
+}

--- a/test/fixtures/experimental/class-private-properties/static/expected.json
+++ b/test/fixtures/experimental/class-private-properties/static/expected.json
@@ -1,7 +1,7 @@
 {
   "type": "File",
   "start": 0,
-  "end": 23,
+  "end": 41,
   "loc": {
     "start": {
       "line": 1,
@@ -15,7 +15,7 @@
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 23,
+    "end": 41,
     "loc": {
       "start": {
         "line": 1,
@@ -31,7 +31,7 @@
       {
         "type": "ClassDeclaration",
         "start": 0,
-        "end": 23,
+        "end": 41,
         "loc": {
           "start": {
             "line": 1,
@@ -45,7 +45,7 @@
         "id": {
           "type": "Identifier",
           "start": 6,
-          "end": 9,
+          "end": 7,
           "loc": {
             "start": {
               "line": 1,
@@ -53,21 +53,21 @@
             },
             "end": {
               "line": 1,
-              "column": 9
+              "column": 7
             },
-            "identifierName": "Foo"
+            "identifierName": "A"
           },
-          "name": "Foo"
+          "name": "A"
         },
         "superClass": null,
         "body": {
           "type": "ClassBody",
-          "start": 10,
-          "end": 23,
+          "start": 8,
+          "end": 41,
           "loc": {
             "start": {
               "line": 1,
-              "column": 10
+              "column": 8
             },
             "end": {
               "line": 4,
@@ -77,8 +77,8 @@
           "body": [
             {
               "type": "ClassPrivateProperty",
-              "start": 14,
-              "end": 16,
+              "start": 12,
+              "end": 22,
               "loc": {
                 "start": {
                   "line": 2,
@@ -86,41 +86,7 @@
                 },
                 "end": {
                   "line": 2,
-                  "column": 4
-                }
-              },
-              "key": {
-                "type": "Identifier",
-                "start": 15,
-                "end": 16,
-                "loc": {
-                  "start": {
-                    "line": 2,
-                    "column": 3
-                  },
-                  "end": {
-                    "line": 2,
-                    "column": 4
-                  },
-                  "identifierName": "x"
-                },
-                "name": "x"
-              },
-              "static": false,
-              "value": null
-            },
-            {
-              "type": "ClassPrivateProperty",
-              "start": 19,
-              "end": 21,
-              "loc": {
-                "start": {
-                  "line": 3,
-                  "column": 2
-                },
-                "end": {
-                  "line": 3,
-                  "column": 4
+                  "column": 12
                 }
               },
               "key": {
@@ -129,19 +95,72 @@
                 "end": 21,
                 "loc": {
                   "start": {
+                    "line": 2,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 11
+                  },
+                  "identifierName": "x"
+                },
+                "name": "x"
+              },
+              "static": true,
+              "value": null
+            },
+            {
+              "type": "ClassPrivateProperty",
+              "start": 25,
+              "end": 39,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 16
+                }
+              },
+              "key": {
+                "type": "Identifier",
+                "start": 33,
+                "end": 34,
+                "loc": {
+                  "start": {
                     "line": 3,
-                    "column": 3
+                    "column": 10
                   },
                   "end": {
                     "line": 3,
-                    "column": 4
+                    "column": 11
                   },
                   "identifierName": "y"
                 },
                 "name": "y"
               },
-              "static": false,
-              "value": null
+              "static": true,
+              "value": {
+                "type": "NumericLiteral",
+                "start": 37,
+                "end": 38,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 15
+                  }
+                },
+                "extra": {
+                  "rawValue": 1,
+                  "raw": "1"
+                },
+                "value": 1
+              }
             }
           ]
         }

--- a/test/fixtures/experimental/class-private-properties/static/options.json
+++ b/test/fixtures/experimental/class-private-properties/static/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["classProperties", "classPrivateProperties"]
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | yes
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | yes
| Fixed tickets     | 
| License           | MIT

Private class fields can be static (according to the [unified proposal](https://github.com/tc39/proposal-class-fields)).