### PR TITLE
Rename PrivateName.name to .id

### DIFF
--- a/ast/spec.md
+++ b/ast/spec.md
@@ -174,7 +174,7 @@ An identifier. Note that an identifier may be an expression or a destructuring p
 ```js
 interface PrivateName <: Expression, Pattern {
   type: "PrivateName";
-  name: Identifier;
+  id: Identifier;
 }
 ```
 A Private Name Identifier.

--- a/src/parser/expression.js
+++ b/src/parser/expression.js
@@ -815,7 +815,7 @@ export default class ExpressionParser extends LValParser {
 
     if (isPrivate) {
       const node = this.startNode();
-      node.name = this.parseIdentifier(true);
+      node.id = this.parseIdentifier(true);
       return this.finishNode(node, "PrivateName");
     } else {
       return this.parseIdentifier(true);

--- a/src/types.js
+++ b/src/types.js
@@ -75,7 +75,7 @@ export type Identifier = PatternBase & {
 
 export type PrivateName = NodeBase & {
   type: "PrivateName",
-  name: string,
+  id: Identifier,
 };
 
 // Literals

--- a/test/fixtures/experimental/class-private-properties/nested/expected.json
+++ b/test/fixtures/experimental/class-private-properties/nested/expected.json
@@ -412,7 +412,7 @@
                               "column": 11
                             }
                           },
-                          "name": {
+                          "id": {
                             "type": "Identifier",
                             "start": 75,
                             "end": 76,
@@ -543,7 +543,7 @@
                               "column": 11
                             }
                           },
-                          "name": {
+                          "id": {
                             "type": "Identifier",
                             "start": 93,
                             "end": 94,
@@ -1047,7 +1047,7 @@
                                               "column": 15
                                             }
                                           },
-                                          "name": {
+                                          "id": {
                                             "type": "Identifier",
                                             "start": 202,
                                             "end": 203,
@@ -1178,7 +1178,7 @@
                                               "column": 15
                                             }
                                           },
-                                          "name": {
+                                          "id": {
                                             "type": "Identifier",
                                             "start": 224,
                                             "end": 225,
@@ -1352,7 +1352,7 @@
                                             "column": 30
                                           }
                                         },
-                                        "name": {
+                                        "id": {
                                           "type": "Identifier",
                                           "start": 270,
                                           "end": 271,
@@ -1521,7 +1521,7 @@
                                               "column": 28
                                             }
                                           },
-                                          "name": {
+                                          "id": {
                                             "type": "Identifier",
                                             "start": 301,
                                             "end": 302,
@@ -1695,7 +1695,7 @@
                                             "column": 30
                                           }
                                         },
-                                        "name": {
+                                        "id": {
                                           "type": "Identifier",
                                           "start": 344,
                                           "end": 345,
@@ -1864,7 +1864,7 @@
                                               "column": 28
                                             }
                                           },
-                                          "name": {
+                                          "id": {
                                             "type": "Identifier",
                                             "start": 375,
                                             "end": 376,
@@ -2084,7 +2084,7 @@
                                                 "column": 32
                                               }
                                             },
-                                            "name": {
+                                            "id": {
                                               "type": "Identifier",
                                               "start": 420,
                                               "end": 421,
@@ -2150,7 +2150,7 @@
                                                 "column": 41
                                               }
                                             },
-                                            "name": {
+                                            "id": {
                                               "type": "Identifier",
                                               "start": 429,
                                               "end": 430,
@@ -2229,7 +2229,7 @@
                                                 "column": 52
                                               }
                                             },
-                                            "name": {
+                                            "id": {
                                               "type": "Identifier",
                                               "start": 440,
                                               "end": 441,
@@ -2295,7 +2295,7 @@
                                                 "column": 61
                                               }
                                             },
-                                            "name": {
+                                            "id": {
                                               "type": "Identifier",
                                               "start": 449,
                                               "end": 450,
@@ -2448,7 +2448,7 @@
                                                 "column": 43
                                               }
                                             },
-                                            "name": {
+                                            "id": {
                                               "type": "Identifier",
                                               "start": 496,
                                               "end": 497,
@@ -2511,7 +2511,7 @@
                                                 "column": 56
                                               }
                                             },
-                                            "name": {
+                                            "id": {
                                               "type": "Identifier",
                                               "start": 509,
                                               "end": 510,
@@ -2720,7 +2720,7 @@
                             "column": 26
                           }
                         },
-                        "name": {
+                        "id": {
                           "type": "Identifier",
                           "start": 554,
                           "end": 555,
@@ -2889,7 +2889,7 @@
                               "column": 24
                             }
                           },
-                          "name": {
+                          "id": {
                             "type": "Identifier",
                             "start": 581,
                             "end": 582,
@@ -3063,7 +3063,7 @@
                             "column": 26
                           }
                         },
-                        "name": {
+                        "id": {
                           "type": "Identifier",
                           "start": 620,
                           "end": 621,
@@ -3232,7 +3232,7 @@
                               "column": 24
                             }
                           },
-                          "name": {
+                          "id": {
                             "type": "Identifier",
                             "start": 647,
                             "end": 648,
@@ -3452,7 +3452,7 @@
                                 "column": 28
                               }
                             },
-                            "name": {
+                            "id": {
                               "type": "Identifier",
                               "start": 688,
                               "end": 689,
@@ -3518,7 +3518,7 @@
                                 "column": 37
                               }
                             },
-                            "name": {
+                            "id": {
                               "type": "Identifier",
                               "start": 697,
                               "end": 698,
@@ -3597,7 +3597,7 @@
                                 "column": 48
                               }
                             },
-                            "name": {
+                            "id": {
                               "type": "Identifier",
                               "start": 708,
                               "end": 709,
@@ -3663,7 +3663,7 @@
                                 "column": 57
                               }
                             },
-                            "name": {
+                            "id": {
                               "type": "Identifier",
                               "start": 717,
                               "end": 718,
@@ -3816,7 +3816,7 @@
                                 "column": 39
                               }
                             },
-                            "name": {
+                            "id": {
                               "type": "Identifier",
                               "start": 760,
                               "end": 761,
@@ -3879,7 +3879,7 @@
                                 "column": 52
                               }
                             },
-                            "name": {
+                            "id": {
                               "type": "Identifier",
                               "start": 773,
                               "end": 774,

--- a/test/fixtures/experimental/class-private-properties/pbn-success/expected.json
+++ b/test/fixtures/experimental/class-private-properties/pbn-success/expected.json
@@ -412,7 +412,7 @@
                               "column": 11
                             }
                           },
-                          "name": {
+                          "id": {
                             "type": "Identifier",
                             "start": 75,
                             "end": 76,
@@ -543,7 +543,7 @@
                               "column": 11
                             }
                           },
-                          "name": {
+                          "id": {
                             "type": "Identifier",
                             "start": 93,
                             "end": 94,
@@ -717,7 +717,7 @@
                             "column": 26
                           }
                         },
-                        "name": {
+                        "id": {
                           "type": "Identifier",
                           "start": 131,
                           "end": 132,
@@ -886,7 +886,7 @@
                               "column": 24
                             }
                           },
-                          "name": {
+                          "id": {
                             "type": "Identifier",
                             "start": 158,
                             "end": 159,
@@ -1060,7 +1060,7 @@
                             "column": 26
                           }
                         },
-                        "name": {
+                        "id": {
                           "type": "Identifier",
                           "start": 197,
                           "end": 198,
@@ -1229,7 +1229,7 @@
                               "column": 24
                             }
                           },
-                          "name": {
+                          "id": {
                             "type": "Identifier",
                             "start": 224,
                             "end": 225,
@@ -1449,7 +1449,7 @@
                                 "column": 28
                               }
                             },
-                            "name": {
+                            "id": {
                               "type": "Identifier",
                               "start": 265,
                               "end": 266,
@@ -1515,7 +1515,7 @@
                                 "column": 37
                               }
                             },
-                            "name": {
+                            "id": {
                               "type": "Identifier",
                               "start": 274,
                               "end": 275,
@@ -1594,7 +1594,7 @@
                                 "column": 48
                               }
                             },
-                            "name": {
+                            "id": {
                               "type": "Identifier",
                               "start": 285,
                               "end": 286,
@@ -1660,7 +1660,7 @@
                                 "column": 57
                               }
                             },
-                            "name": {
+                            "id": {
                               "type": "Identifier",
                               "start": 294,
                               "end": 295,
@@ -1813,7 +1813,7 @@
                                 "column": 39
                               }
                             },
-                            "name": {
+                            "id": {
                               "type": "Identifier",
                               "start": 337,
                               "end": 338,
@@ -1876,7 +1876,7 @@
                                 "column": 52
                               }
                             },
-                            "name": {
+                            "id": {
                               "type": "Identifier",
                               "start": 350,
                               "end": 351,


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | not for release
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | no
| Tests added/pass? | yes
| Fixed tickets     | N/A
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->
Given that it refers to an identifier, it's somewhat confusing to have
to use `.name.name` to get the actual string. The type declared within
types.js is also incorrect, which this commit fixes.

This will also require anything using PrivateName in the main Babel repository to be changed, but it's probably better we do this now rather than after release.