### PR TITLE
Add allowPrimitiveOverride option to flowParseTypeAnnotatableIdentifier

### DIFF
--- a/src/plugins/flow.js
+++ b/src/plugins/flow.js
@@ -180,7 +180,9 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       node: N.FlowDeclareVariable,
     ): N.FlowDeclareVariable {
       this.next();
-      node.id = this.flowParseTypeAnnotatableIdentifier();
+      node.id = this.flowParseTypeAnnotatableIdentifier(
+        /*allowPrimitiveOverride*/ true,
+      );
       this.semicolon();
       return this.finishNode(node, "DeclareVariable");
     }
@@ -1145,8 +1147,12 @@ export default (superClass: Class<Parser>): Class<Parser> =>
       return this.finishNode(node, "TypeAnnotation");
     }
 
-    flowParseTypeAnnotatableIdentifier(): N.Identifier {
-      const ident = this.flowParseRestrictedIdentifier();
+    flowParseTypeAnnotatableIdentifier(
+      allowPrimitiveOverride?: boolean,
+    ): N.Identifier {
+      const ident = allowPrimitiveOverride
+        ? this.parseIdentifier()
+        : this.flowParseRestrictedIdentifier();
       if (this.match(tt.colon)) {
         ident.typeAnnotation = this.flowParseTypeAnnotation();
         this.finishNode(ident, ident.type);

--- a/test/fixtures/flow/declare-statements/19/actual.js
+++ b/test/fixtures/flow/declare-statements/19/actual.js
@@ -1,0 +1,1 @@
+declare var string: any;

--- a/test/fixtures/flow/declare-statements/19/expected.json
+++ b/test/fixtures/flow/declare-statements/19/expected.json
@@ -1,0 +1,96 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 24,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 24
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 24,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 24
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "DeclareVariable",
+        "start": 0,
+        "end": 24,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 24
+          }
+        },
+        "id": {
+          "type": "Identifier",
+          "start": 12,
+          "end": 23,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 12
+            },
+            "end": {
+              "line": 1,
+              "column": 23
+            },
+            "identifierName": "string"
+          },
+          "name": "string",
+          "typeAnnotation": {
+            "type": "TypeAnnotation",
+            "start": 18,
+            "end": 23,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 18
+              },
+              "end": {
+                "line": 1,
+                "column": 23
+              }
+            },
+            "typeAnnotation": {
+              "type": "AnyTypeAnnotation",
+              "start": 20,
+              "end": 23,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 20
+                },
+                "end": {
+                  "line": 1,
+                  "column": 23
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | y
| Breaking change?  | n
| New feature?      | n
| Deprecations?     | n
| Spec compliancy?  | y
| Tests added/pass? | y/y
| Fixed tickets     | 
| License           | MIT

Reported at https://github.com/prettier/prettier/issues/2696
