### PR TITLE
Bump rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "nyc": "^11.0.3",
     "prettier": "^1.5.2",
     "rimraf": "^2.5.4",
-    "rollup": "^0.48.0",
+    "rollup": "^0.49.3",
     "rollup-plugin-babel": "^3.0.1",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-watch": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2035,7 +2035,7 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@0.54.1:
+flow-bin@^0.54.1:
   version "0.54.1"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.54.1.tgz#7101bcccf006dc0652714a8aef0c72078a760510"
 
@@ -3845,9 +3845,9 @@ rollup-watch@^4.0.0:
     require-relative "0.8.7"
     rollup-pluginutils "^2.0.1"
 
-rollup@^0.48.0:
-  version "0.48.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.48.1.tgz#61fb3799600443169cd3b95480437fcc42bdf9b2"
+rollup@^0.49.3:
+  version "0.49.3"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.49.3.tgz#4cce32643dd8cf2154c69ff0e43470067db0adbf"
 
 run-async@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
Looks like `0.49.3` (specifically https://github.com/rollup/rollup/pull/1604) works :)

Supersedes and closes https://github.com/babel/babylon/pull/701