### PR TITLE
Set generators to false for all arrow functions.

### DIFF
--- a/ast/spec.md
+++ b/ast/spec.md
@@ -628,6 +628,7 @@ interface ArrowFunctionExpression <: Function, Expression {
   type: "ArrowFunctionExpression";
   body: BlockStatement | Expression;
   expression: boolean;
+  generator: false;
 }
 ```
 


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | N/A
| Fixed tickets     | N/A
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->

See [the MDN page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#Use_of_the_yield_keyword) on arrow functions, which says that arrow functions cannot be generator functions.

Keep up the good work! 😄 
Eli