### PR TITLE
Fix NumericLiteralSeparator SyntaxError message to match V8

### DIFF
--- a/src/tokenizer/index.js
+++ b/src/tokenizer/index.js
@@ -733,7 +733,7 @@ export default class Tokenizer extends LocationParser {
             forbiddenSiblings.indexOf(next) > -1 ||
             Number.isNaN(next)
           ) {
-            this.raise(this.state.pos, "Invalid NumericLiteralSeparator");
+            this.raise(this.state.pos, "Invalid or unexpected token");
           }
 
           // Ignore this _ character

--- a/test/fixtures/experimental/numeric-separator/invalid-0/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-0/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:1)" }
+{ "throws": "Invalid or unexpected token (1:1)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-1/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-1/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:3)" }
+{ "throws": "Invalid or unexpected token (1:3)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-10/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-10/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:5)" }
+{ "throws": "Invalid or unexpected token (1:5)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-11/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-11/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:5)" }
+{ "throws": "Invalid or unexpected token (1:5)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-12/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-12/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:2)" }
+{ "throws": "Invalid or unexpected token (1:2)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-13/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-13/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:2)" }
+{ "throws": "Invalid or unexpected token (1:2)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-14/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-14/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:2)" }
+{ "throws": "Invalid or unexpected token (1:2)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-15/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-15/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:2)" }
+{ "throws": "Invalid or unexpected token (1:2)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-16/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-16/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:2)" }
+{ "throws": "Invalid or unexpected token (1:2)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-17/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-17/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:2)" }
+{ "throws": "Invalid or unexpected token (1:2)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-18/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-18/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:2)" }
+{ "throws": "Invalid or unexpected token (1:2)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-19/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-19/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:2)" }
+{ "throws": "Invalid or unexpected token (1:2)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-2/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-2/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:3)" }
+{ "throws": "Invalid or unexpected token (1:3)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-20/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-20/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:2)" }
+{ "throws": "Invalid or unexpected token (1:2)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-21/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-21/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:6)" }
+{ "throws": "Invalid or unexpected token (1:6)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-22/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-22/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:5)" }
+{ "throws": "Invalid or unexpected token (1:5)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-23/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-23/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:2)" }
+{ "throws": "Invalid or unexpected token (1:2)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-3/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-3/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:1)" }
+{ "throws": "Invalid or unexpected token (1:1)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-4/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-4/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:3)" }
+{ "throws": "Invalid or unexpected token (1:3)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-5/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-5/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:4)" }
+{ "throws": "Invalid or unexpected token (1:4)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-6/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-6/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:5)" }
+{ "throws": "Invalid or unexpected token (1:5)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-7/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-7/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:5)" }
+{ "throws": "Invalid or unexpected token (1:5)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-8/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-8/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:6)" }
+{ "throws": "Invalid or unexpected token (1:6)" }

--- a/test/fixtures/experimental/numeric-separator/invalid-9/options.json
+++ b/test/fixtures/experimental/numeric-separator/invalid-9/options.json
@@ -1,1 +1,1 @@
-{ "throws": "Invalid NumericLiteralSeparator (1:6)" }
+{ "throws": "Invalid or unexpected token (1:6)" }


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | yes
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests pass? | yes
| Fixed tickets     | comma-separated list of tickets fixed by the PR, if any
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->

The error message that accompanied the SyntaxError will now match the message that would come from V8