### PR TITLE
Specify id to be null for arrow functions.

### DIFF
--- a/ast/spec.md
+++ b/ast/spec.md
@@ -626,6 +626,7 @@ A `this` expression.
 ```js
 interface ArrowFunctionExpression <: Function, Expression {
   type: "ArrowFunctionExpression";
+  id: null;
   body: BlockStatement | Expression;
   expression: boolean;
 }


### PR DESCRIPTION
<!--- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/babel/babylon/blob/master/CONTRIBUTING.md
-->

| Q                 | A
| ----------------- | ---
| Bug fix?          | no
| Breaking change?  | no
| New feature?      | no
| Deprecations?     | no
| Spec compliancy?  | yes
| Tests added/pass? | no
| Fixed tickets     | #747
| License           | MIT

<!-- Describe your changes below in as much detail as possible -->

The [ArrowFunctionExpression section of the AST specification](https://github.com/babel/babylon/blob/master/ast/spec.md#arrowfunctionexpression) should probably clarify that supplying an `Identifier` for `id` does nothing, by explicitly saying `id: null`. Of course, we don't need to change `babel-generator` or `babel-types` to accommodate this change, because that would only hurt backwards compatibility.

Thanks,
Eli