### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ require("babylon").parse("code", {
 | `bigInt` ([proposal](https://github.com/tc39/proposal-bigint)) | `100n` |
 | `optionalCatchBinding` ([proposal](https://github.com/babel/proposals/issues/7)) | `try {throw 0;} catch{do();}` |
 | `throwExpressions` ([proposal](https://github.com/babel/proposals/issues/23)) | `() => throw new Error("")` |
-| `pipelineOperator` ([proposal](https://github.com/babel/proposals/issues/29)) | `a |> b` |
+| `pipelineOperator` ([proposal](https://github.com/babel/proposals/issues/29)) | `a \|> b` |
 
 ### FAQ
 


### PR DESCRIPTION
Amusingly the pipeline OP "breaks" the readme formatting because Markdown likes the `|` character a bit too much. Escaping the `|` fixes this and makes the readme display properly.

Just a single character README change.